### PR TITLE
feat: configurable nodeSelector and tolerations for scanner pods

### DIFF
--- a/api/context/context.go
+++ b/api/context/context.go
@@ -60,6 +60,15 @@ type KubernetesConfig struct {
 	ProxyAddress         string
 	NoProxyAddresses     string
 	PodSchedulingTimeout int
+	NodeSelector         map[string]string
+	Tolerations          []TolerationConfig
+}
+
+// TolerationConfig holds a single Kubernetes toleration parsed from env.
+type TolerationConfig struct {
+	Key    string
+	Value  string
+	Effect string
 }
 
 // GraylogConfig represents Graylog configuration.
@@ -326,13 +335,63 @@ func (dF DefaultConfig) getKubernetesConfig() *KubernetesConfig {
 	if err != nil {
 		podSchedulingTimeout = 60
 	}
+	nodeSelector := parseNodeSelector(dF.Caller.GetEnvironmentVariable("HUSKYCI_KUBERNETES_NODE_SELECTOR"))
+	tolerations := parseTolerations(dF.Caller.GetEnvironmentVariable("HUSKYCI_KUBERNETES_TOLERATIONS"))
 	return &KubernetesConfig{
 		ConfigFilePath:       configFilePath,
 		Namespace:            namespace,
 		ProxyAddress:         proxyAddress,
 		NoProxyAddresses:     noProxyAddresses,
 		PodSchedulingTimeout: podSchedulingTimeout,
+		NodeSelector:         nodeSelector,
+		Tolerations:          tolerations,
 	}
+}
+
+// parseNodeSelector parses a comma-separated list of key=value pairs.
+// Example: "karpenter.sh/nodepool=actions-runner,env=prod"
+func parseNodeSelector(raw string) map[string]string {
+	result := map[string]string{}
+	if raw == "" {
+		return result
+	}
+	for _, pair := range strings.Split(raw, ",") {
+		pair = strings.TrimSpace(pair)
+		parts := strings.SplitN(pair, "=", 2)
+		if len(parts) == 2 {
+			result[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+		}
+	}
+	return result
+}
+
+// parseTolerations parses a comma-separated list of key=value:effect entries.
+// Example: "actions-runner=true:NoSchedule,another-key=val:NoExecute"
+func parseTolerations(raw string) []TolerationConfig {
+	var result []TolerationConfig
+	if raw == "" {
+		return result
+	}
+	for _, entry := range strings.Split(raw, ",") {
+		entry = strings.TrimSpace(entry)
+		// Split on ":" to separate key=value from effect
+		colonParts := strings.SplitN(entry, ":", 2)
+		if len(colonParts) != 2 {
+			continue
+		}
+		kvPart := strings.TrimSpace(colonParts[0])
+		effect := strings.TrimSpace(colonParts[1])
+		kvSplit := strings.SplitN(kvPart, "=", 2)
+		if len(kvSplit) != 2 {
+			continue
+		}
+		result = append(result, TolerationConfig{
+			Key:    strings.TrimSpace(kvSplit[0]),
+			Value:  strings.TrimSpace(kvSplit[1]),
+			Effect: effect,
+		})
+	}
+	return result
 }
 
 // GetDockerAPIPort will return the port number

--- a/api/context/context_test.go
+++ b/api/context/context_test.go
@@ -333,6 +333,8 @@ var _ = Describe("Context", func() {
 						ProxyAddress:         fakeCaller.expectedEnvVar,
 						NoProxyAddresses:     fakeCaller.expectedEnvVar,
 						PodSchedulingTimeout: fakeCaller.expectedIntegerValue,
+						NodeSelector:         map[string]string{},
+						Tolerations:          nil,
 					},
 					EnrySecurityTest: &types.SecurityTest{
 						Name:             fakeCaller.expectedStringFromConfig,

--- a/api/kubernetes/api.go
+++ b/api/kubernetes/api.go
@@ -26,6 +26,8 @@ type Kubernetes struct {
 	Namespace        string
 	ProxyAddress     string
 	NoProxyAddresses string
+	NodeSelector     map[string]string
+	Tolerations      []core.Toleration
 }
 
 const logActionNew = "NewKubernetes"
@@ -55,10 +57,26 @@ func NewKubernetes() (*Kubernetes, error) {
 		Namespace:        configAPI.KubernetesConfig.Namespace,
 		ProxyAddress:     configAPI.KubernetesConfig.ProxyAddress,
 		NoProxyAddresses: configAPI.KubernetesConfig.NoProxyAddresses,
+		NodeSelector:     configAPI.KubernetesConfig.NodeSelector,
+		Tolerations:      buildTolerations(configAPI.KubernetesConfig.Tolerations),
 	}
 
 	return kubernetes, nil
 
+}
+
+// buildTolerations converts parsed TolerationConfig entries into Kubernetes Toleration objects.
+func buildTolerations(configs []apiContext.TolerationConfig) []core.Toleration {
+	var tolerations []core.Toleration
+	for _, tc := range configs {
+		tolerations = append(tolerations, core.Toleration{
+			Key:      tc.Key,
+			Operator: core.TolerationOpEqual,
+			Value:    tc.Value,
+			Effect:   core.TaintEffect(tc.Effect),
+		})
+	}
+	return tolerations
 }
 
 func (k Kubernetes) CreatePod(image, cmd, podName, securityTestName string) (string, error) {
@@ -100,6 +118,8 @@ func (k Kubernetes) CreatePod(image, cmd, podName, securityTestName string) (str
 					},
 				},
 			},
+			NodeSelector: k.NodeSelector,
+			Tolerations:  k.Tolerations,
 			TopologySpreadConstraints: []core.TopologySpreadConstraint{
 				{
 					MaxSkew:           1,


### PR DESCRIPTION
## Summary

-- Scanner pods (enry, bandit, gitleaks, etc.) now support `nodeSelector` and `tolerations` via environment variables
-- Fixes pod scheduling timeouts caused by all scanner pods landing on a single node during burst analysis runs

## Problem

HuskyCI API creates scanner pods with no scheduling constraints. The ScaleOps mutating webhook injects a high-packing node affinity that concentrates all pods on a single node. During burst runs (multiple repos triggering SAST simultaneously), the node saturates and new pods can't schedule within the 5-minute timeout, failing the analysis.

Related: SREEE-792

## Changes

| File | What |
|------|------|
| `api/context/context.go` | Extended `KubernetesConfig` with `NodeSelector` and `Tolerations` fields; added `parseNodeSelector()` and `parseTolerations()` helpers |
| `api/kubernetes/api.go` | Wire new fields into `Kubernetes` struct and apply to `PodSpec` in `CreatePod()`; added `buildTolerations()` converter |
| `api/context/context_test.go` | Updated expected struct in existing test to include new fields |

## Configuration

Two new optional environment variables:

```
HUSKYCI_KUBERNETES_NODE_SELECTOR=karpenter.sh/nodepool=actions-runner
HUSKYCI_KUBERNETES_TOLERATIONS=actions-runner=true:NoSchedule
```

Both support comma-separated entries for multiple values. Empty or unset preserves current behavior (no nodeSelector, no tolerations).

## Deployment

After merging, add the env vars to the `huskyci-api` Helm values in `k8s-infrastructure-live` (`components/huskyci/stable/values.yaml`).