### PR TITLE
fix: gitauthors clone performance and clarify vulnerability exit output

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -34,31 +34,23 @@ gitauthors:
     chmod 600 ~/.ssh/huskyci_id_rsa &&
     echo "IdentityFile ~/.ssh/huskyci_id_rsa" >> /etc/ssh/ssh_config &&
     echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
-    dbg() { echo "[gitauthors][$(date -u +%H:%M:%S)] $1" >> /tmp/gitauthors_debug.log; }
     GIT_TERMINAL_PROMPT=0 git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneEnry
     if [ $? -ne 0 ]; then
       echo "ERROR_CLONING"
       cat /tmp/errorGitCloneEnry
       exit 1
     fi
-    dbg "clone done"
     cd code
     git fetch origin master:refs/remotes/origin/master --quiet 2> /dev/null
-    dbg "fetch master done (exit=$?)"
     git branch -a | egrep 'remotes/origin/master' 1> /dev/null 2> /dev/null
     if [ $? -ne 0 ]; then
-      dbg "no origin/master, returning empty"
       echo "{\"authors\":[]}"
       exit 0
     fi
-    dbg "running git log origin/master.."
-    authorCount=$(git log origin/master.. --pretty="%ae" | sort -u | wc -l | tr -d ' ')
-    dbg "found $authorCount unique authors"
     for i in $(git log origin/master.. --pretty="%ae" | sort -u); do
       jsonMiddle="\"${i//[^A-Za-z0-9_\.@-]/}\",$jsonMiddle"
     done
-    dbg "done"
-    echo "{\"authors\":[${jsonMiddle%?}],\"_debug\":\"$(cat /tmp/gitauthors_debug.log | tr '\n' '|')\"}"
+    echo "{\"authors\":[${jsonMiddle%?}]}"
   type: Generic
   default: true
   timeOutInSeconds: 360

--- a/api/config.yaml
+++ b/api/config.yaml
@@ -34,23 +34,23 @@ gitauthors:
     chmod 600 ~/.ssh/huskyci_id_rsa &&
     echo "IdentityFile ~/.ssh/huskyci_id_rsa" >> /etc/ssh/ssh_config &&
     echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
-    GIT_TERMINAL_PROMPT=0 git clone %GIT_REPO% code --quiet 2> /tmp/errorGitCloneEnry
+    GIT_TERMINAL_PROMPT=0 git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneEnry
+    if [ $? -ne 0 ]; then
+      echo "ERROR_CLONING"
+      cat /tmp/errorGitCloneEnry
+      exit 1
+    fi
     cd code
+    git fetch origin master:refs/remotes/origin/master --quiet 2> /dev/null
     git branch -a | egrep 'remotes/origin/master' 1> /dev/null 2> /dev/null
     if [ $? -ne 0 ]; then
       echo "{\"authors\":[]}"
       exit 0
     fi
-    git checkout %GIT_BRANCH% --quiet
-    if [ $? -eq 0 ]; then
-      for i in $(git log origin/master.. --pretty="%ae" | sort -u); do
-        jsonMiddle="\"${i//[^A-Za-z0-9_\.@-]/}\",$jsonMiddle"
-      done
-      echo "{\"authors\":[${jsonMiddle%?}]}"
-    else
-      echo "ERROR_CLONING"
-      cat /tmp/errorGitCloneEnry
-    fi
+    for i in $(git log origin/master.. --pretty="%ae" | sort -u); do
+      jsonMiddle="\"${i//[^A-Za-z0-9_\.@-]/}\",$jsonMiddle"
+    done
+    echo "{\"authors\":[${jsonMiddle%?}]}"
   type: Generic
   default: true
   timeOutInSeconds: 360

--- a/api/config.yaml
+++ b/api/config.yaml
@@ -34,23 +34,31 @@ gitauthors:
     chmod 600 ~/.ssh/huskyci_id_rsa &&
     echo "IdentityFile ~/.ssh/huskyci_id_rsa" >> /etc/ssh/ssh_config &&
     echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
+    dbg() { echo "[gitauthors][$(date -u +%H:%M:%S)] $1" >> /tmp/gitauthors_debug.log; }
     GIT_TERMINAL_PROMPT=0 git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneEnry
     if [ $? -ne 0 ]; then
       echo "ERROR_CLONING"
       cat /tmp/errorGitCloneEnry
       exit 1
     fi
+    dbg "clone done"
     cd code
     git fetch origin master:refs/remotes/origin/master --quiet 2> /dev/null
+    dbg "fetch master done (exit=$?)"
     git branch -a | egrep 'remotes/origin/master' 1> /dev/null 2> /dev/null
     if [ $? -ne 0 ]; then
+      dbg "no origin/master, returning empty"
       echo "{\"authors\":[]}"
       exit 0
     fi
+    dbg "running git log origin/master.."
+    authorCount=$(git log origin/master.. --pretty="%ae" | sort -u | wc -l | tr -d ' ')
+    dbg "found $authorCount unique authors"
     for i in $(git log origin/master.. --pretty="%ae" | sort -u); do
       jsonMiddle="\"${i//[^A-Za-z0-9_\.@-]/}\",$jsonMiddle"
     done
-    echo "{\"authors\":[${jsonMiddle%?}]}"
+    dbg "done"
+    echo "{\"authors\":[${jsonMiddle%?}],\"_debug\":\"$(cat /tmp/gitauthors_debug.log | tr '\n' '|')\"}"
   type: Generic
   default: true
   timeOutInSeconds: 360

--- a/api/context/context.go
+++ b/api/context/context.go
@@ -64,7 +64,7 @@ type KubernetesConfig struct {
 	Tolerations          []TolerationConfig
 }
 
-// TolerationConfig holds a single Kubernetes toleration parsed from env.
+// TolerationConfig represents a parsed Kubernetes toleration.
 type TolerationConfig struct {
 	Key    string
 	Value  string
@@ -348,8 +348,7 @@ func (dF DefaultConfig) getKubernetesConfig() *KubernetesConfig {
 	}
 }
 
-// parseNodeSelector parses a comma-separated list of key=value pairs.
-// Example: "karpenter.sh/nodepool=actions-runner,env=prod"
+// parseNodeSelector parses a comma-separated "key=value" string into a map.
 func parseNodeSelector(raw string) map[string]string {
 	result := map[string]string{}
 	if raw == "" {
@@ -357,16 +356,15 @@ func parseNodeSelector(raw string) map[string]string {
 	}
 	for _, pair := range strings.Split(raw, ",") {
 		pair = strings.TrimSpace(pair)
-		parts := strings.SplitN(pair, "=", 2)
-		if len(parts) == 2 {
-			result[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+		kv := strings.SplitN(pair, "=", 2)
+		if len(kv) == 2 {
+			result[strings.TrimSpace(kv[0])] = strings.TrimSpace(kv[1])
 		}
 	}
 	return result
 }
 
-// parseTolerations parses a comma-separated list of key=value:effect entries.
-// Example: "actions-runner=true:NoSchedule,another-key=val:NoExecute"
+// parseTolerations parses a comma-separated "key=value:effect" string.
 func parseTolerations(raw string) []TolerationConfig {
 	var result []TolerationConfig
 	if raw == "" {
@@ -374,21 +372,18 @@ func parseTolerations(raw string) []TolerationConfig {
 	}
 	for _, entry := range strings.Split(raw, ",") {
 		entry = strings.TrimSpace(entry)
-		// Split on ":" to separate key=value from effect
-		colonParts := strings.SplitN(entry, ":", 2)
-		if len(colonParts) != 2 {
+		parts := strings.SplitN(entry, ":", 2)
+		if len(parts) != 2 {
 			continue
 		}
-		kvPart := strings.TrimSpace(colonParts[0])
-		effect := strings.TrimSpace(colonParts[1])
-		kvSplit := strings.SplitN(kvPart, "=", 2)
-		if len(kvSplit) != 2 {
+		kv := strings.SplitN(strings.TrimSpace(parts[0]), "=", 2)
+		if len(kv) != 2 {
 			continue
 		}
 		result = append(result, TolerationConfig{
-			Key:    strings.TrimSpace(kvSplit[0]),
-			Value:  strings.TrimSpace(kvSplit[1]),
-			Effect: effect,
+			Key:    strings.TrimSpace(kv[0]),
+			Value:  strings.TrimSpace(kv[1]),
+			Effect: strings.TrimSpace(parts[1]),
 		})
 	}
 	return result

--- a/api/context/parse_test.go
+++ b/api/context/parse_test.go
@@ -1,0 +1,129 @@
+package context
+
+import (
+	"testing"
+)
+
+func TestParseNodeSelector(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected map[string]string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: map[string]string{},
+		},
+		{
+			name:     "single pair",
+			input:    "karpenter.sh/nodepool=actions-runner",
+			expected: map[string]string{"karpenter.sh/nodepool": "actions-runner"},
+		},
+		{
+			name:  "multiple pairs",
+			input: "karpenter.sh/nodepool=actions-runner,env=prod",
+			expected: map[string]string{
+				"karpenter.sh/nodepool": "actions-runner",
+				"env":                   "prod",
+			},
+		},
+		{
+			name:     "whitespace around pairs",
+			input:    " foo=bar , baz=qux ",
+			expected: map[string]string{"foo": "bar", "baz": "qux"},
+		},
+		{
+			name:     "malformed entry skipped",
+			input:    "good=value,noequals,also=fine",
+			expected: map[string]string{"good": "value", "also": "fine"},
+		},
+		{
+			name:     "value containing equals",
+			input:    "key=val=ue",
+			expected: map[string]string{"key": "val=ue"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseNodeSelector(tt.input)
+			if len(got) != len(tt.expected) {
+				t.Fatalf("got %d entries, want %d: %v", len(got), len(tt.expected), got)
+			}
+			for k, v := range tt.expected {
+				if got[k] != v {
+					t.Errorf("key %q: got %q, want %q", k, got[k], v)
+				}
+			}
+		})
+	}
+}
+
+func TestParseTolerations(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []TolerationConfig
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: nil,
+		},
+		{
+			name:  "single toleration",
+			input: "actions-runner=true:NoSchedule",
+			expected: []TolerationConfig{
+				{Key: "actions-runner", Value: "true", Effect: "NoSchedule"},
+			},
+		},
+		{
+			name:  "multiple tolerations",
+			input: "actions-runner=true:NoSchedule,gpu=nvidia:NoExecute",
+			expected: []TolerationConfig{
+				{Key: "actions-runner", Value: "true", Effect: "NoSchedule"},
+				{Key: "gpu", Value: "nvidia", Effect: "NoExecute"},
+			},
+		},
+		{
+			name:  "whitespace tolerance",
+			input: " actions-runner=true:NoSchedule , gpu=nvidia:NoExecute ",
+			expected: []TolerationConfig{
+				{Key: "actions-runner", Value: "true", Effect: "NoSchedule"},
+				{Key: "gpu", Value: "nvidia", Effect: "NoExecute"},
+			},
+		},
+		{
+			name:     "missing effect skipped",
+			input:    "actions-runner=true",
+			expected: nil,
+		},
+		{
+			name:     "missing value skipped",
+			input:    "actions-runner:NoSchedule",
+			expected: nil,
+		},
+		{
+			name:  "key with slash",
+			input: "karpenter.sh/do-not-disrupt=true:NoSchedule",
+			expected: []TolerationConfig{
+				{Key: "karpenter.sh/do-not-disrupt", Value: "true", Effect: "NoSchedule"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseTolerations(tt.input)
+			if len(got) != len(tt.expected) {
+				t.Fatalf("got %d entries, want %d: %v", len(got), len(tt.expected), got)
+			}
+			for i := range tt.expected {
+				if got[i] != tt.expected[i] {
+					t.Errorf("index %d: got %+v, want %+v", i, got[i], tt.expected[i])
+				}
+			}
+		})
+	}
+}

--- a/api/kubernetes/api.go
+++ b/api/kubernetes/api.go
@@ -65,7 +65,7 @@ func NewKubernetes() (*Kubernetes, error) {
 
 }
 
-// buildTolerations converts parsed TolerationConfig entries into Kubernetes Toleration objects.
+// buildTolerations converts TolerationConfig entries into core.Toleration objects.
 func buildTolerations(configs []apiContext.TolerationConfig) []core.Toleration {
 	var tolerations []core.Toleration
 	for _, tc := range configs {

--- a/api/kubernetes/api_test.go
+++ b/api/kubernetes/api_test.go
@@ -1,0 +1,85 @@
+package kubernetes
+
+import (
+	"testing"
+
+	apiContext "github.com/githubanotaai/huskyci-api/api/context"
+	core "k8s.io/api/core/v1"
+)
+
+func TestBuildTolerations(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []apiContext.TolerationConfig
+		expected []core.Toleration
+	}{
+		{
+			name:     "nil input",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name:     "empty slice",
+			input:    []apiContext.TolerationConfig{},
+			expected: nil,
+		},
+		{
+			name: "single toleration",
+			input: []apiContext.TolerationConfig{
+				{Key: "actions-runner", Value: "true", Effect: "NoSchedule"},
+			},
+			expected: []core.Toleration{
+				{
+					Key:      "actions-runner",
+					Operator: core.TolerationOpEqual,
+					Value:    "true",
+					Effect:   core.TaintEffectNoSchedule,
+				},
+			},
+		},
+		{
+			name: "multiple tolerations",
+			input: []apiContext.TolerationConfig{
+				{Key: "actions-runner", Value: "true", Effect: "NoSchedule"},
+				{Key: "gpu", Value: "nvidia", Effect: "NoExecute"},
+			},
+			expected: []core.Toleration{
+				{
+					Key:      "actions-runner",
+					Operator: core.TolerationOpEqual,
+					Value:    "true",
+					Effect:   core.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "gpu",
+					Operator: core.TolerationOpEqual,
+					Value:    "nvidia",
+					Effect:   core.TaintEffectNoExecute,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildTolerations(tt.input)
+			if len(got) != len(tt.expected) {
+				t.Fatalf("got %d tolerations, want %d", len(got), len(tt.expected))
+			}
+			for i := range tt.expected {
+				if got[i].Key != tt.expected[i].Key {
+					t.Errorf("[%d] Key: got %q, want %q", i, got[i].Key, tt.expected[i].Key)
+				}
+				if got[i].Operator != tt.expected[i].Operator {
+					t.Errorf("[%d] Operator: got %q, want %q", i, got[i].Operator, tt.expected[i].Operator)
+				}
+				if got[i].Value != tt.expected[i].Value {
+					t.Errorf("[%d] Value: got %q, want %q", i, got[i].Value, tt.expected[i].Value)
+				}
+				if got[i].Effect != tt.expected[i].Effect {
+					t.Errorf("[%d] Effect: got %q, want %q", i, got[i].Effect, tt.expected[i].Effect)
+				}
+			}
+		})
+	}
+}

--- a/client/cmd/main.go
+++ b/client/cmd/main.go
@@ -134,6 +134,11 @@ func main() {
 		}
 		fmt.Println("[HUSKYCI][*] Some HIGH/MEDIUM issues were found in these securityTests:")
 		fmt.Println("[HUSKYCI][*]", failedList)
+		fmt.Println()
+		fmt.Println("[HUSKYCI][!] ⚠ Analysis completed successfully but blocking vulnerabilities were found.")
+		fmt.Println("[HUSKYCI][!] This is NOT an infrastructure error. The exit code 190 signals that")
+		fmt.Println("[HUSKYCI][!] HIGH or MEDIUM severity issues must be resolved before merging.")
+		fmt.Println("[HUSKYCI][!] Review the findings above and fix them, or use 'nohusky' tags to suppress false positives.")
 	}
 
 	os.Exit(190)

--- a/client/cmd/main.go
+++ b/client/cmd/main.go
@@ -135,10 +135,9 @@ func main() {
 		fmt.Println("[HUSKYCI][*] Some HIGH/MEDIUM issues were found in these securityTests:")
 		fmt.Println("[HUSKYCI][*]", failedList)
 		fmt.Println()
-		fmt.Println("[HUSKYCI][!] ⚠ Analysis completed successfully but blocking vulnerabilities were found.")
-		fmt.Println("[HUSKYCI][!] This is NOT an infrastructure error. The exit code 190 signals that")
-		fmt.Println("[HUSKYCI][!] HIGH or MEDIUM severity issues must be resolved before merging.")
-		fmt.Println("[HUSKYCI][!] Review the findings above and fix them, or use 'nohusky' tags to suppress false positives.")
+		fmt.Println("[HUSKYCI][!] Analysis completed. Blocking vulnerabilities (HIGH/MEDIUM) were found.")
+		fmt.Println("[HUSKYCI][!] This is NOT an infrastructure error -- the security scan ran successfully.")
+		fmt.Println("[HUSKYCI][!] Fix the vulnerabilities listed above before merging.")
 	}
 
 	os.Exit(190)

--- a/deployments/dockerfiles/client.Dockerfile
+++ b/deployments/dockerfiles/client.Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.23-alpine AS builder
+RUN apk add --no-cache git
+WORKDIR /app
+COPY client/ ./client/
+WORKDIR /app/client
+RUN go mod download
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /huskyci-client ./cmd/main.go
+
+FROM alpine:3.19
+RUN apk add --no-cache ca-certificates git openssh-client
+COPY --from=builder /huskyci-client /usr/local/bin/huskyci-client
+ENTRYPOINT ["huskyci-client"]


### PR DESCRIPTION
## Summary

-- gitauthors scanner switched to `--single-branch` clone with targeted master ref fetch, timeout bumped from 60s to 360s
-- Exit code 190 output now explicitly states the scan succeeded and vulnerabilities must be fixed
-- Added `client.Dockerfile` for tracked huskyci-client image builds

## Problem

**gitauthors**: Full `git clone` (no `--single-branch`) plus `git log` across entire repo history. On large repos this exceeded the 60s timeout consistently, failing the analysis.

**Exit code 190**: When HIGH/MEDIUM vulnerabilities are found, the client exits 190. ARC then prints `Executing the custom container implementation failed`, making developers think infrastructure is broken when the scan actually succeeded.

## Changes

| File | What |
|------|------|
| `api/config.yaml` | gitauthors: `--single-branch` clone + `git fetch origin master` for author comparison, timeout 60s -> 360s |
| `client/cmd/main.go` | Clear message before `os.Exit(190)` stating the scan succeeded and vulns must be fixed |
| `deployments/dockerfiles/client.Dockerfile` | Multi-stage Dockerfile (Go 1.23 build, Alpine 3.19 runtime) |