### PR TITLE
feat: improve client output readability and Dockerfile

### DIFF
--- a/client/analysis/output.go
+++ b/client/analysis/output.go
@@ -24,60 +24,55 @@ func printJSONOutput() error {
 	return nil
 }
 
-// printSTDOUTOutput prints the analysis output in STDOUT using printfs
+// printSTDOUTOutput prints the analysis output in STDOUT using printfs.
+// Summary is printed first so developers see the overview immediately,
+// then vulnerability details are wrapped in GitHub Actions collapsible groups.
 func printSTDOUTOutput(analysis types.Analysis) {
+	printAllSummary(analysis)
 
 	// gosec
-	printSTDOUTOutputGosec(outputJSON.GoResults.HuskyCIGosecOutput.LowVulns)
-	printSTDOUTOutputGosec(outputJSON.GoResults.HuskyCIGosecOutput.MediumVulns)
-	printSTDOUTOutputGosec(outputJSON.GoResults.HuskyCIGosecOutput.HighVulns)
+	printToolGroup("Go - GoSec", outputJSON.GoResults.HuskyCIGosecOutput, printSTDOUTOutputGosec)
 
 	// bandit
-	printSTDOUTOutputBandit(outputJSON.PythonResults.HuskyCIBanditOutput.LowVulns)
-	printSTDOUTOutputBandit(outputJSON.PythonResults.HuskyCIBanditOutput.MediumVulns)
-	printSTDOUTOutputBandit(outputJSON.PythonResults.HuskyCIBanditOutput.HighVulns)
+	printToolGroup("Python - Bandit", outputJSON.PythonResults.HuskyCIBanditOutput, printSTDOUTOutputBandit)
 
 	// safety
-	printSTDOUTOutputSafety(outputJSON.PythonResults.HuskyCISafetyOutput.LowVulns)
-	printSTDOUTOutputSafety(outputJSON.PythonResults.HuskyCISafetyOutput.MediumVulns)
-	printSTDOUTOutputSafety(outputJSON.PythonResults.HuskyCISafetyOutput.HighVulns)
+	printToolGroup("Python - Safety", outputJSON.PythonResults.HuskyCISafetyOutput, printSTDOUTOutputSafety)
 
 	// brakeman
-	printSTDOUTOutputBrakeman(outputJSON.RubyResults.HuskyCIBrakemanOutput.LowVulns)
-	printSTDOUTOutputBrakeman(outputJSON.RubyResults.HuskyCIBrakemanOutput.MediumVulns)
-	printSTDOUTOutputBrakeman(outputJSON.RubyResults.HuskyCIBrakemanOutput.HighVulns)
+	printToolGroup("Ruby - Brakeman", outputJSON.RubyResults.HuskyCIBrakemanOutput, printSTDOUTOutputBrakeman)
 
 	// npmaudit
-	printSTDOUTOutputNpmAudit(outputJSON.JavaScriptResults.HuskyCINpmAuditOutput.LowVulns)
-	printSTDOUTOutputNpmAudit(outputJSON.JavaScriptResults.HuskyCINpmAuditOutput.MediumVulns)
-	printSTDOUTOutputNpmAudit(outputJSON.JavaScriptResults.HuskyCINpmAuditOutput.HighVulns)
+	printToolGroup("JavaScript - NpmAudit", outputJSON.JavaScriptResults.HuskyCINpmAuditOutput, printSTDOUTOutputNpmAudit)
 
 	// yarnaudit
-	printSTDOUTOutputYarnAudit(outputJSON.JavaScriptResults.HuskyCIYarnAuditOutput.LowVulns)
-	printSTDOUTOutputYarnAudit(outputJSON.JavaScriptResults.HuskyCIYarnAuditOutput.MediumVulns)
-	printSTDOUTOutputYarnAudit(outputJSON.JavaScriptResults.HuskyCIYarnAuditOutput.HighVulns)
+	printToolGroup("JavaScript - YarnAudit", outputJSON.JavaScriptResults.HuskyCIYarnAuditOutput, printSTDOUTOutputYarnAudit)
 
 	// gitleaks
-	printSTDOUTOutputGitleaks(outputJSON.GenericResults.HuskyCIGitleaksOutput.LowVulns)
-	printSTDOUTOutputGitleaks(outputJSON.GenericResults.HuskyCIGitleaksOutput.MediumVulns)
-	printSTDOUTOutputGitleaks(outputJSON.GenericResults.HuskyCIGitleaksOutput.HighVulns)
+	printToolGroup("Generic - Gitleaks", outputJSON.GenericResults.HuskyCIGitleaksOutput, printSTDOUTOutputGitleaks)
 
 	// spotbugs
-	printSTDOUTOutputSpotBugs(outputJSON.JavaResults.HuskyCISpotBugsOutput.LowVulns)
-	printSTDOUTOutputSpotBugs(outputJSON.JavaResults.HuskyCISpotBugsOutput.MediumVulns)
-	printSTDOUTOutputSpotBugs(outputJSON.JavaResults.HuskyCISpotBugsOutput.HighVulns)
+	printToolGroup("Java - SpotBugs", outputJSON.JavaResults.HuskyCISpotBugsOutput, printSTDOUTOutputSpotBugs)
 
 	// tfsec
-	printSTDOUTOutputTFSec(outputJSON.HclResults.HuskyCITFSecOutput.LowVulns)
-	printSTDOUTOutputTFSec(outputJSON.HclResults.HuskyCITFSecOutput.MediumVulns)
-	printSTDOUTOutputTFSec(outputJSON.HclResults.HuskyCITFSecOutput.HighVulns)
+	printToolGroup("HCL - TFSec", outputJSON.HclResults.HuskyCITFSecOutput, printSTDOUTOutputTFSec)
 
 	// securitycodescan
-	printSTDOUTOutputSecurityCodeScan(outputJSON.CSharpResults.HuskyCISecurityCodeScanOutput.LowVulns)
-	printSTDOUTOutputSecurityCodeScan(outputJSON.CSharpResults.HuskyCISecurityCodeScanOutput.MediumVulns)
-	printSTDOUTOutputSecurityCodeScan(outputJSON.CSharpResults.HuskyCISecurityCodeScanOutput.HighVulns)
+	printToolGroup("C# - SecurityCodeScan", outputJSON.CSharpResults.HuskyCISecurityCodeScanOutput, printSTDOUTOutputSecurityCodeScan)
+}
 
-	printAllSummary(analysis)
+// printToolGroup prints vulnerability details inside a GitHub Actions collapsible group.
+// The group is only emitted when there are actual findings (low + medium + high > 0).
+func printToolGroup(name string, output types.HuskyCISecurityTestOutput, printFn func([]types.HuskyCIVulnerability)) {
+	total := len(output.LowVulns) + len(output.MediumVulns) + len(output.HighVulns)
+	if total == 0 {
+		return
+	}
+	fmt.Printf("::group::%s Details (%d findings)\n", name, total)
+	printFn(output.LowVulns)
+	printFn(output.MediumVulns)
+	printFn(output.HighVulns)
+	fmt.Println("::endgroup::")
 }
 
 // prepareAllSummary prepares how many low, medium and high vulnerabilites were found.

--- a/client/integration/sonarqube/sonarqube.go
+++ b/client/integration/sonarqube/sonarqube.go
@@ -125,12 +125,6 @@ func GenerateOutputFile(analysis types.Analysis, outputPath, outputFileName stri
 		return err
 	}
 
-	absolutePath, err := filepath.Abs(filepath.Join(outputPath, outputFileName))
-	if err != nil {
-		return fmt.Errorf("failed to resolve absolute path: %w", err)
-	}
-	fmt.Printf("[DEBUG] Absolute path for SonarQube JSON file: %s\n", absolutePath)
-
 	err = util.CreateFile(sonarOutputString, outputPath, outputFileName)
 	if err != nil {
 		return err

--- a/deployments/dockerfiles/client.Dockerfile
+++ b/deployments/dockerfiles/client.Dockerfile
@@ -1,12 +1,31 @@
 FROM golang:1.23-alpine AS builder
-RUN apk add --no-cache git
-WORKDIR /app
-COPY client/ ./client/
-WORKDIR /app/client
-RUN go mod download
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /huskyci-client ./cmd/main.go
 
-FROM alpine:3.19
-RUN apk add --no-cache ca-certificates git openssh-client
+RUN apk update && apk upgrade \
+    && apk add --no-cache git
+
+WORKDIR /build
+
+COPY client/go.mod client/go.sum ./
+RUN go mod download
+
+COPY client/ ./
+RUN CGO_ENABLED=0 go build -ldflags "-s -w" -o /huskyci-client ./cmd/main.go
+
+FROM alpine:3.21
+
+RUN apk update && apk upgrade \
+    && apk add --no-cache \
+    ca-certificates \
+    curl \
+    git \
+    openssh-client
+
 COPY --from=builder /huskyci-client /usr/local/bin/huskyci-client
-ENTRYPOINT ["huskyci-client"]
+
+COPY deployments/dockerfiles/huskyci-client/huskyci-client-entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+WORKDIR /workspace
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["huskyci-client"]

--- a/deployments/dockerfiles/huskyci-client/huskyci-client-entrypoint.sh
+++ b/deployments/dockerfiles/huskyci-client/huskyci-client-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+git config --global --add safe.directory '*'
+
+exec "$@"


### PR DESCRIPTION
## Summary

-- Reorder client output: summary first, details in collapsible groups
-- Remove DEBUG log line
-- Replace client Dockerfile with production-ready version

## Output changes

Before: 200+ lines of vulnerability details, then summary at the bottom.
After: summary at the top, each tool's details in `::group::` / `::endgroup::` collapsible sections.

Developers see this first:
```
[HUSKYCI][SUMMARY] Total
[HUSKYCI][SUMMARY] High: 29
[HUSKYCI][SUMMARY] Medium: 3
[HUSKYCI][SUMMARY] Low: 3
```

Then each tool's findings are in a collapsible group they can expand if needed.

## Dockerfile changes

Based on Guilherme's Dockerfile with adjustments:
-- Separate `go.mod`/`go.sum` copy for Docker layer caching
-- `-ldflags "-s -w"` for smaller binary (strip debug info)
-- Entrypoint script with `git safe.directory` config
-- Pinned `alpine:3.21` instead of `latest`