### PR TITLE
feat: use ECR for gitleaks image

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -332,7 +332,7 @@ spotbugs:
 
 gitleaks:
   name: gitleaks
-  image: huskyci/gitleaks
+  image: 939030204144.dkr.ecr.us-east-1.amazonaws.com/huskyci-gitleaks
   imageTag: "8.30.1"
   cmd: |+
     mkdir -p ~/.ssh &&


### PR DESCRIPTION
Updates gitleaks scanner to use ECR image `939030204144.dkr.ecr.us-east-1.amazonaws.com/huskyci-gitleaks:8.30.1` instead of Docker Hub.

This ensures the image is accessible from EKS nodes.