### PR TITLE
fix(wizcli): pass auth via CLI flags and surface auth failures

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -430,9 +430,7 @@ wizcli:
     echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
     GIT_TERMINAL_PROMPT=0 git clone -b %GIT_BRANCH% --single-branch --depth 1 %GIT_REPO% code --quiet 2>/tmp/errorGitCloneWiz
     if [ $? -eq 0 ]; then
-        export WIZ_CLIENT_ID='%WIZ_CLIENT_ID%'
-        export WIZ_CLIENT_SECRET='%WIZ_CLIENT_SECRET%'
-        wizcli auth > /tmp/errorWizAuth 2>&1
+        wizcli auth --id '%WIZ_CLIENT_ID%' --secret '%WIZ_CLIENT_SECRET%' > /tmp/errorWizAuth 2>&1
         if [ $? -ne 0 ]; then
             echo 'ERROR_AUTH_WIZCLI'
             cat /tmp/errorWizAuth

--- a/api/securitytest/wizcli.go
+++ b/api/securitytest/wizcli.go
@@ -20,8 +20,8 @@ func analyzeWizCLI(scanInfo *SecTestScanInfo) error {
 	output := scanInfo.Container.COutput
 
 	if strings.Contains(output, "ERROR_AUTH_WIZCLI") {
-		scanInfo.ErrorFound = nil
-		return nil
+		scanInfo.ErrorFound = errors.New("wizcli authentication failed (ERROR_AUTH_WIZCLI)")
+		return scanInfo.ErrorFound
 	}
 
 	if strings.Contains(output, "ERROR_RUNNING_WIZCLI_SCAN") {

--- a/api/securitytest/wizcli_test.go
+++ b/api/securitytest/wizcli_test.go
@@ -289,16 +289,19 @@ func TestAnalyzeWizCLI_SeverityBuckets(t *testing.T) {
 
 // ── TestAnalyzeWizCLI_ErrorAuth ───────────────────────────────────────────────
 
+// TestAnalyzeWizCLI_ErrorAuth verifies that ERROR_AUTH_WIZCLI surfaces as an
+// error so authentication failures are not silently swallowed.
 func TestAnalyzeWizCLI_ErrorAuth(t *testing.T) {
 	scanInfo := &SecTestScanInfo{}
 	scanInfo.Container.COutput = "ERROR_AUTH_WIZCLI: authentication failed"
 	scanInfo.ErrorFound = nil
 
-	if err := analyzeWizCLI(scanInfo); err != nil {
-		t.Fatalf("analyzeWizCLI returned unexpected error: %v", err)
+	err := analyzeWizCLI(scanInfo)
+	if err == nil {
+		t.Fatal("expected non-nil error when ERROR_AUTH_WIZCLI is present, got nil")
 	}
-	if scanInfo.ErrorFound != nil {
-		t.Errorf("expected ErrorFound to be nil after auth error, got %v", scanInfo.ErrorFound)
+	if scanInfo.ErrorFound == nil {
+		t.Error("expected scanInfo.ErrorFound to be set, got nil")
 	}
 
 	total := len(scanInfo.Vulnerabilities.HighVulns) +


### PR DESCRIPTION
## Summary

`wizcli` v1.45 in `huskyci-wiz:latest-amd64` ignores the environment-variable auth flow when invoked as `wizcli auth` with no flags, so every analysis was failing authentication and emitting an `ERROR_AUTH` sentinel in the pod output. The parser was then silently swallowing that sentinel as a non-error, which made the client report `no blocking vulnerabilities` while wiz never actually scanned anything.

This PR addresses both layers:

- **`api/config.yaml`** — invoke `wizcli auth --id ... --secret ...` so the CLI receives the values directly. Env vars alone don't authenticate in the current wizcli release.
- **`api/securitytest/wizcli.go`** — surface `ERROR_AUTH` as an actual `ErrorFound` (mirrors the `ERROR_RUNNING_WIZCLI_SCAN` branch right below it), so any future auth regression is visible instead of silently dropped.
- **`api/securitytest/wizcli_test.go`** — update `TestAnalyzeWizCLI_ErrorAuth` to match the new contract.

## Evidence

Reproduced live in the prod `huskyci` namespace using `huskyci-wiz:latest-amd64` against the live values:

| Test | Result |
|---|---|
| `wizcli auth` (env vars only) | `ERROR: Not authenticated` (exit `3`) |
| `wizcli auth --id ... --secret ...` | `Authenticated successfully.` (exit `0`) |
| `wizcli dir scan` after the flag-based auth | `Verdict: PASSED_BY_POLICY`, finding reported to Wiz Cloud Event |

Same value works in both cases — confirming the inputs are valid and the regression is purely in how `wizcli auth` reads them.

## Test plan

- [x] `go vet ./...` (api)
- [x] `go test -race -count=1 ./...` (api) — all green, including the updated `TestAnalyzeWizCLI_ErrorAuth`
- [ ] After merge, build/push image and bump tag in `k8s-infrastructure-live` `components/huskyci/{next,unreleased}/values.yaml`, then re-run a SAST workflow on a target repo and confirm the wiz section shows real scan output instead of an empty success.
