### PR TITLE
feat(wizcli): switch scanner output to JSON and parse it

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -436,10 +436,14 @@ wizcli:
             cat /tmp/errorWizAuth
         else
             wizcli dir scan --path ./code --sensitive-data --secrets \
-              --file-hashes-scan --policy "aai-secrets-default-policy" 2>&1
+              --file-hashes-scan --policy "aai-secrets-default-policy" \
+              -f json > /tmp/wizResult.json 2> /tmp/errorWizScan
             SCAN_RC=$?
             if [ $SCAN_RC -ge 2 ]; then
               echo "ERROR_RUNNING_WIZCLI_SCAN"
+              cat /tmp/errorWizScan
+            else
+              cat /tmp/wizResult.json
             fi
         fi
     else

--- a/api/securitytest/testdata/wizcli_v1_json_sample.json
+++ b/api/securitytest/testdata/wizcli_v1_json_sample.json
@@ -1,0 +1,867 @@
+{
+  "id": "0069faa4-330b-8e5c-932c-970e54148001",
+  "projects": [
+    {
+      "id": "b4ce9215-eca0-50f1-97b3-6c0224097997"
+    }
+  ],
+  "createdAt": "2026-05-06T02:15:22.245239962Z",
+  "startedAt": "2026-05-06T02:15:15.871529285Z",
+  "createdBy": {
+    "serviceAccount": {
+      "id": "***REDACTED***"
+    }
+  },
+  "status": {
+    "state": "SUCCESS",
+    "verdict": "PASSED_BY_POLICY"
+  },
+  "policies": [
+    {
+      "id": "5e9561cf-2548-4b9f-93ab-0b4056c1fc23",
+      "name": "aai-secrets-default-policy",
+      "description": null,
+      "type": "SECRETS",
+      "builtin": false,
+      "projects": [
+        {
+          "id": "b4ce9215-eca0-50f1-97b3-6c0224097997"
+        }
+      ],
+      "policyLifecycleEnforcements": [
+        {
+          "enforcementMethod": "AUDIT",
+          "deploymentLifecycle": "CLI"
+        },
+        {
+          "enforcementMethod": "AUDIT",
+          "deploymentLifecycle": "CODE"
+        }
+      ],
+      "ignoreRules": null,
+      "lifecycleTargets": [
+        "BUILD",
+        "CODE"
+      ],
+      "Default": false,
+      "params": {
+        "__typename": "cicdscanpolicyparamssecrets",
+        "countThreshold": 1,
+        "pathAllowList": null,
+        "secretFindingSeverityThreshold": "LOW",
+        "disallowedValidationStatus": null
+      }
+    }
+  ],
+  "extraInfo": {
+    "clientName": "WizCLI",
+    "clientVersion": "1.45.0-9c936d6",
+    "buildParams": {
+      "platform": "UNKNOWN"
+    }
+  },
+  "tags": null,
+  "outdatedPolicies": null,
+  "taggedResource": null,
+  "associatedBaselineScans": null,
+  "outputMessages": null,
+  "scanOriginResource": {
+    "__typename": "CICDScanOriginDirectory",
+    "name": "/code"
+  },
+  "result": {
+    "__typename": "CICDDiskScanResult",
+    "osPackages": null,
+    "libraries": [
+      {
+        "name": "lodash",
+        "version": "4.17.4",
+        "path": "/package-lock.json",
+        "startLine": 5,
+        "endLine": 5,
+        "vulnerabilities": [
+          {
+            "name": "CVE-2026-4800",
+            "severity": "HIGH",
+            "fixedVersion": "4.18.0",
+            "fileRemediation": null,
+            "source": "https://github.com/advisories/GHSA-r5fr-rjxr-66jc",
+            "description": "Impact:\n\nThe fix for CVE-2021-23337 (https://github.com/advisories/GHSA-35jh-r3h4-6jhm) added validation for the variable option in _.template but did not apply the same validation to options.imports key names. Both paths flow into the same Function() constructor sink.\n\nWhen an application passes untrusted input as options.imports key names, an attacker can inject default-parameter expressions that execute arbitrary code at template compilation time.\n\nAdditionally, _.template uses assignInWith to merge imports, which enumerates inherited properties via for..in. If Object.prototype has been polluted by any other vector, the polluted keys are copied into the imports object and passed to Function().\n\nPatches:\n\nUsers should upgrade to version 4.18.0.\n\nWorkarounds:\n\nDo not pass untrusted input as key names in options.imports. Only use developer-controlled, static key names.",
+            "score": 9.8,
+            "exploitabilityScore": 3.9,
+            "cvssV3Metrics": {
+              "attackComplexity": "LOW",
+              "attackVector": "NETWORK",
+              "confidentialityImpact": "HIGH",
+              "integrityImpact": "HIGH",
+              "privilegesRequired": "NONE",
+              "userInteractionRequired": false
+            },
+            "cvssV2Metrics": {
+              "attackComplexity": null,
+              "attackVector": null,
+              "confidentialityImpact": null,
+              "integrityImpact": null,
+              "privilegesRequired": null,
+              "userInteractionRequired": false
+            },
+            "cvssV3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:X/RL:X/RC:X",
+            "cvssV4Vector": null,
+            "hasExploit": true,
+            "hasCisaKevExploit": false,
+            "cisaKevReleaseDate": null,
+            "cisaKevDueDate": null,
+            "epssProbability": 0,
+            "epssPercentile": 11.3,
+            "epssSeverity": "LOW",
+            "weightedSeverity": "CRITICAL",
+            "publishDate": "2026-03-31T20:16:00Z",
+            "fixPublishDate": "2026-04-02T20:44:01Z",
+            "gracePeriodEnd": null,
+            "gracePeriodRemainingHours": null,
+            "failedPolicyMatches": null,
+            "finding": {
+              "id": "9cb8c680-2cab-5d95-8892-5c3541c7cb3b"
+            },
+            "ignoredPolicyMatches": null
+          },
+          {
+            "name": "CVE-2018-16487",
+            "severity": "HIGH",
+            "fixedVersion": "4.17.11",
+            "fileRemediation": null,
+            "source": "https://github.com/advisories/GHSA-4xc9-xhrj-v574",
+            "description": "A prototype pollution vulnerability was found in lodash <4.17.11 where the functions merge, mergeWith, and defaultsDeep can be tricked into adding or modifying properties of Object.prototype.",
+            "score": 5.6,
+            "exploitabilityScore": 2.2,
+            "cvssV3Metrics": {
+              "attackComplexity": "HIGH",
+              "attackVector": "NETWORK",
+              "confidentialityImpact": "LOW",
+              "integrityImpact": "LOW",
+              "privilegesRequired": "NONE",
+              "userInteractionRequired": false
+            },
+            "cvssV2Metrics": {
+              "attackComplexity": "MEDIUM",
+              "attackVector": "NETWORK",
+              "confidentialityImpact": "PARTIAL",
+              "integrityImpact": "PARTIAL",
+              "privilegesRequired": "NONE",
+              "userInteractionRequired": false
+            },
+            "cvssV3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L",
+            "cvssV4Vector": null,
+            "hasExploit": true,
+            "hasCisaKevExploit": false,
+            "cisaKevReleaseDate": null,
+            "cisaKevDueDate": null,
+            "epssProbability": 0.5,
+            "epssPercentile": 66.4,
+            "epssSeverity": "HIGH",
+            "weightedSeverity": "MEDIUM",
+            "publishDate": "2019-02-01T18:29:00Z",
+            "fixPublishDate": "2023-06-05T00:00:00Z",
+            "gracePeriodEnd": null,
+            "gracePeriodRemainingHours": null,
+            "failedPolicyMatches": null,
+            "finding": {
+              "id": "2dd7df8f-e19b-5663-af83-5bb54c29e67a"
+            },
+            "ignoredPolicyMatches": null
+          },
+          {
+            "name": "CVE-2018-3721",
+            "severity": "MEDIUM",
+            "fixedVersion": "4.17.5",
+            "fileRemediation": null,
+            "source": "https://github.com/advisories/GHSA-fvqr-27wr-82fm",
+            "description": "lodash node module before 4.17.5 suffers from a Modification of Assumed-Immutable Data (MAID) vulnerability via defaultsDeep, merge, and mergeWith functions, which allows a malicious user to modify the prototype of \"Object\" via __proto__, causing the addition or modification of an existing property that will exist on all objects.",
+            "score": 6.5,
+            "exploitabilityScore": 2.8,
+            "cvssV3Metrics": {
+              "attackComplexity": "LOW",
+              "attackVector": "NETWORK",
+              "confidentialityImpact": "NONE",
+              "integrityImpact": "HIGH",
+              "privilegesRequired": "LOW",
+              "userInteractionRequired": false
+            },
+            "cvssV2Metrics": {
+              "attackComplexity": "LOW",
+              "attackVector": "NETWORK",
+              "confidentialityImpact": "NONE",
+              "integrityImpact": "PARTIAL",
+              "privilegesRequired": "SINGLE",
+              "userInteractionRequired": false
+            },
+            "cvssV3Vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:N",
+            "cvssV4Vector": null,
+            "hasExploit": true,
+            "hasCisaKevExploit": false,
+            "cisaKevReleaseDate": null,
+            "cisaKevDueDate": null,
+            "epssProbability": 0.3,
+            "epssPercentile": 48.8,
+            "epssSeverity": "LOW",
+            "weightedSeverity": "MEDIUM",
+            "publishDate": "2018-06-07T02:29:00Z",
+            "fixPublishDate": "2023-06-05T00:00:00Z",
+            "gracePeriodEnd": null,
+            "gracePeriodRemainingHours": null,
+            "failedPolicyMatches": null,
+            "finding": {
+              "id": "8c9f6797-bd10-5b53-aa7b-dfe669c5726f"
+            },
+            "ignoredPolicyMatches": null
+          },
+          {
+            "name": "CVE-2019-1010266",
+            "severity": "MEDIUM",
+            "fixedVersion": "4.17.11",
+            "fileRemediation": null,
+            "source": "https://github.com/advisories/GHSA-x5rq-j2xg-h7qm",
+            "description": "lodash prior to 4.17.11 is affected by: CWE-400: Uncontrolled Resource Consumption. The impact is: Denial of service. The component is: Date handler. The attack vector is: Attacker provides very long strings, which the library attempts to match using a regular expression. The fixed version is: 4.17.11.",
+            "score": 6.5,
+            "exploitabilityScore": 2.8,
+            "cvssV3Metrics": {
+              "attackComplexity": "LOW",
+              "attackVector": "NETWORK",
+              "confidentialityImpact": "NONE",
+              "integrityImpact": "NONE",
+              "privilegesRequired": "LOW",
+              "userInteractionRequired": false
+            },
+            "cvssV2Metrics": {
+              "attackComplexity": "LOW",
+              "attackVector": "NETWORK",
+              "confidentialityImpact": "NONE",
+              "integrityImpact": "NONE",
+              "privilegesRequired": "SINGLE",
+              "userInteractionRequired": false
+            },
+            "cvssV3Vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+            "cvssV4Vector": null,
+            "hasExploit": true,
+            "hasCisaKevExploit": false,
+            "cisaKevReleaseDate": null,
+            "cisaKevDueDate": null,
+            "epssProbability": 0.2,
+            "epssPercentile": 43.6,
+            "epssSeverity": "LOW",
+            "weightedSeverity": "LOW",
+            "publishDate": "2019-07-17T21:15:00Z",
+            "fixPublishDate": "2023-06-05T00:00:00Z",
+            "gracePeriodEnd": null,
+            "gracePeriodRemainingHours": null,
+            "failedPolicyMatches": null,
+            "finding": {
+              "id": "93de9030-5d95-5c69-891f-321dc57af3f1"
+            },
+            "ignoredPolicyMatches": null
+          },
+          {
+            "name": "CVE-2021-23337",
+            "severity": "HIGH",
+            "fixedVersion": "4.17.21",
+            "fileRemediation": null,
+            "source": "https://github.com/advisories/GHSA-35jh-r3h4-6jhm",
+            "description": "Lodash versions prior to 4.17.21 are vulnerable to Command Injection via the template function.",
+            "score": 7.2,
+            "exploitabilityScore": 1.2,
+            "cvssV3Metrics": {
+              "attackComplexity": "LOW",
+              "attackVector": "NETWORK",
+              "confidentialityImpact": "HIGH",
+              "integrityImpact": "HIGH",
+              "privilegesRequired": "HIGH",
+              "userInteractionRequired": false
+            },
+            "cvssV2Metrics": {
+              "attackComplexity": "LOW",
+              "attackVector": "NETWORK",
+              "confidentialityImpact": "PARTIAL",
+              "integrityImpact": "PARTIAL",
+              "privilegesRequired": "SINGLE",
+              "userInteractionRequired": false
+            },
+            "cvssV3Vector": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H",
+            "cvssV4Vector": null,
+            "hasExploit": true,
+            "hasCisaKevExploit": false,
+            "cisaKevReleaseDate": null,
+            "cisaKevDueDate": null,
+            "epssProbability": 4.3,
+            "epssPercentile": 88.9,
+            "epssSeverity": "CRITICAL",
+            "weightedSeverity": "HIGH",
+            "publishDate": "2021-02-15T13:15:00Z",
+            "fixPublishDate": "2023-06-05T00:00:00Z",
+            "gracePeriodEnd": null,
+            "gracePeriodRemainingHours": null,
+            "failedPolicyMatches": null,
+            "finding": {
+              "id": "9740e2ca-52fc-5503-8a25-9d21f2de7603"
+            },
+            "ignoredPolicyMatches": null
+          },
+          {
+            "name": "CVE-2025-13465",
+            "severity": "MEDIUM",
+            "fixedVersion": "4.17.23",
+            "fileRemediation": null,
+            "source": "https://github.com/advisories/GHSA-xxjr-mmjv-4gpg",
+            "description": "Lodash versions 4.0.0 through 4.17.22 are vulnerable to prototype pollution in the _.unset and _.omit functions. An attacker can pass crafted paths which cause Lodash to delete methods from global prototypes.\n\nThe issue permits deletion of properties but does not allow overwriting their original behavior.\n\nThis issue is patched on 4.17.23",
+            "score": 6.9,
+            "exploitabilityScore": 3.9,
+            "cvssV3Metrics": {
+              "attackComplexity": "LOW",
+              "attackVector": "NETWORK",
+              "confidentialityImpact": "NONE",
+              "integrityImpact": "LOW",
+              "privilegesRequired": "NONE",
+              "userInteractionRequired": false
+            },
+            "cvssV2Metrics": {
+              "attackComplexity": null,
+              "attackVector": null,
+              "confidentialityImpact": null,
+              "integrityImpact": null,
+              "privilegesRequired": null,
+              "userInteractionRequired": false
+            },
+            "cvssV3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
+            "cvssV4Vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:L/VA:L/SC:H/SI:H/SA:H/E:P/CR:X/IR:X/AR:X/MAV:X/MAC:X/MAT:X/MPR:X/MUI:X/MVC:X/MVI:X/MVA:X/MSC:X/MSI:X/MSA:X/S:X/AU:X/R:X/V:X/RE:X/U:X",
+            "hasExploit": false,
+            "hasCisaKevExploit": false,
+            "cisaKevReleaseDate": null,
+            "cisaKevDueDate": null,
+            "epssProbability": 0,
+            "epssPercentile": 8.3,
+            "epssSeverity": "LOW",
+            "weightedSeverity": "LOW",
+            "publishDate": "2026-01-21T20:16:00Z",
+            "fixPublishDate": "2026-01-22T06:44:04Z",
+            "gracePeriodEnd": null,
+            "gracePeriodRemainingHours": null,
+            "failedPolicyMatches": null,
+            "finding": {
+              "id": "831c4ab7-fd4c-5566-8b33-390a055e3963"
+            },
+            "ignoredPolicyMatches": null
+          },
+          {
+            "name": "CVE-2020-28500",
+            "severity": "MEDIUM",
+            "fixedVersion": "4.17.21",
+            "fileRemediation": null,
+            "source": "https://github.com/advisories/GHSA-29mw-wpgm-hmr9",
+            "description": "Lodash versions prior to 4.17.21 are vulnerable to Regular Expression Denial of Service (ReDoS) via the toNumber, trim and trimEnd functions.",
+            "score": 5.3,
+            "exploitabilityScore": 3.9,
+            "cvssV3Metrics": {
+              "attackComplexity": "LOW",
+              "attackVector": "NETWORK",
+              "confidentialityImpact": "NONE",
+              "integrityImpact": "NONE",
+              "privilegesRequired": "NONE",
+              "userInteractionRequired": false
+            },
+            "cvssV2Metrics": {
+              "attackComplexity": "LOW",
+              "attackVector": "NETWORK",
+              "confidentialityImpact": "NONE",
+              "integrityImpact": "NONE",
+              "privilegesRequired": "NONE",
+              "userInteractionRequired": false
+            },
+            "cvssV3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+            "cvssV4Vector": null,
+            "hasExploit": true,
+            "hasCisaKevExploit": false,
+            "cisaKevReleaseDate": null,
+            "cisaKevDueDate": null,
+            "epssProbability": 0.2,
+            "epssPercentile": 47.6,
+            "epssSeverity": "LOW",
+            "weightedSeverity": "LOW",
+            "publishDate": "2021-02-15T11:15:00Z",
+            "fixPublishDate": "2023-06-05T00:00:00Z",
+            "gracePeriodEnd": null,
+            "gracePeriodRemainingHours": null,
+            "failedPolicyMatches": null,
+            "finding": {
+              "id": "4ea98376-2fba-54e0-9d10-3ac6e792b2e5"
+            },
+            "ignoredPolicyMatches": null
+          },
+          {
+            "name": "CVE-2020-8203",
+            "severity": "HIGH",
+            "fixedVersion": "4.17.19",
+            "fileRemediation": null,
+            "source": "https://github.com/advisories/GHSA-p6mc-m468-83gw",
+            "description": "Prototype pollution attack when using _.zipObjectDeep in lodash before 4.17.20.",
+            "score": 7.4,
+            "exploitabilityScore": 2.2,
+            "cvssV3Metrics": {
+              "attackComplexity": "HIGH",
+              "attackVector": "NETWORK",
+              "confidentialityImpact": "NONE",
+              "integrityImpact": "HIGH",
+              "privilegesRequired": "NONE",
+              "userInteractionRequired": false
+            },
+            "cvssV2Metrics": {
+              "attackComplexity": "MEDIUM",
+              "attackVector": "NETWORK",
+              "confidentialityImpact": "NONE",
+              "integrityImpact": "PARTIAL",
+              "privilegesRequired": "NONE",
+              "userInteractionRequired": false
+            },
+            "cvssV3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:H/A:H",
+            "cvssV4Vector": null,
+            "hasExploit": false,
+            "hasCisaKevExploit": false,
+            "cisaKevReleaseDate": null,
+            "cisaKevDueDate": null,
+            "epssProbability": 3.3,
+            "epssPercentile": 87.3,
+            "epssSeverity": "CRITICAL",
+            "weightedSeverity": "CRITICAL",
+            "publishDate": "2020-07-15T17:15:00Z",
+            "fixPublishDate": "2023-06-05T00:00:00Z",
+            "gracePeriodEnd": null,
+            "gracePeriodRemainingHours": null,
+            "failedPolicyMatches": null,
+            "finding": {
+              "id": "ebfbdc3e-3280-58ce-ada0-49ef0ef30d99"
+            },
+            "ignoredPolicyMatches": null
+          },
+          {
+            "name": "CVE-2026-2950",
+            "severity": "MEDIUM",
+            "fixedVersion": "4.18.0",
+            "fileRemediation": null,
+            "source": "https://github.com/advisories/GHSA-f23m-r3pf-42rh",
+            "description": "Impact:\n\nLodash versions 4.17.23 and earlier are vulnerable to prototype pollution in the _.unset and _.omit functions. The fix for (CVE-2025-13465: https://github.com/lodash/lodash/security/advisories/GHSA-xxjr-mmjv-4gpg) only guards against string key members, so an attacker can bypass the check by passing array-wrapped path segments. This allows deletion of properties from built-in prototypes such as Object.prototype, Number.prototype, and String.prototype.\n\nThe issue permits deletion of prototype properties but does not allow overwriting their original behavior.\n\nPatches:\n\nThis issue is patched in 4.18.0.\n\nWorkarounds:\n\nNone. Upgrade to the patched version.",
+            "score": 5.3,
+            "exploitabilityScore": 3.9,
+            "cvssV3Metrics": {
+              "attackComplexity": "LOW",
+              "attackVector": "NETWORK",
+              "confidentialityImpact": "NONE",
+              "integrityImpact": "LOW",
+              "privilegesRequired": "NONE",
+              "userInteractionRequired": false
+            },
+            "cvssV2Metrics": {
+              "attackComplexity": null,
+              "attackVector": null,
+              "confidentialityImpact": null,
+              "integrityImpact": null,
+              "privilegesRequired": null,
+              "userInteractionRequired": false
+            },
+            "cvssV3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
+            "cvssV4Vector": null,
+            "hasExploit": false,
+            "hasCisaKevExploit": false,
+            "cisaKevReleaseDate": null,
+            "cisaKevDueDate": null,
+            "epssProbability": 0,
+            "epssPercentile": 7,
+            "epssSeverity": "LOW",
+            "weightedSeverity": "LOW",
+            "publishDate": "2026-03-31T20:16:00Z",
+            "fixPublishDate": "2026-04-02T20:44:01Z",
+            "gracePeriodEnd": null,
+            "gracePeriodRemainingHours": null,
+            "failedPolicyMatches": null,
+            "finding": {
+              "id": "47feaa30-ab24-5aad-9385-3f333cc56986"
+            },
+            "ignoredPolicyMatches": null
+          },
+          {
+            "name": "CVE-2019-10744",
+            "severity": "CRITICAL",
+            "fixedVersion": "4.17.12",
+            "fileRemediation": null,
+            "source": "https://github.com/advisories/GHSA-jf85-cpcp-j695",
+            "description": "Versions of lodash lower than 4.17.12 are vulnerable to Prototype Pollution. The function defaultsDeep could be tricked into adding or modifying properties of Object.prototype using a constructor payload.",
+            "score": 9.1,
+            "exploitabilityScore": 3.9,
+            "cvssV3Metrics": {
+              "attackComplexity": "LOW",
+              "attackVector": "NETWORK",
+              "confidentialityImpact": "NONE",
+              "integrityImpact": "HIGH",
+              "privilegesRequired": "NONE",
+              "userInteractionRequired": false
+            },
+            "cvssV2Metrics": {
+              "attackComplexity": "LOW",
+              "attackVector": "NETWORK",
+              "confidentialityImpact": "NONE",
+              "integrityImpact": "PARTIAL",
+              "privilegesRequired": "NONE",
+              "userInteractionRequired": false
+            },
+            "cvssV3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:H",
+            "cvssV4Vector": null,
+            "hasExploit": true,
+            "hasCisaKevExploit": false,
+            "cisaKevReleaseDate": null,
+            "cisaKevDueDate": null,
+            "epssProbability": 3.3,
+            "epssPercentile": 87.4,
+            "epssSeverity": "CRITICAL",
+            "weightedSeverity": "CRITICAL",
+            "publishDate": "2019-07-26T00:15:00Z",
+            "fixPublishDate": "2023-06-05T00:00:00Z",
+            "gracePeriodEnd": null,
+            "gracePeriodRemainingHours": null,
+            "failedPolicyMatches": null,
+            "finding": {
+              "id": "a86d55c1-4710-560d-b35e-c77bbaaef876"
+            },
+            "ignoredPolicyMatches": null
+          }
+        ],
+        "detectionMethod": "LIBRARY",
+        "layerMetadata": null,
+        "failedPolicyMatches": null,
+        "resolvedDependencyTree": null
+      },
+      {
+        "name": "express",
+        "version": "4.16.0",
+        "path": "/package-lock.json",
+        "startLine": 6,
+        "endLine": 6,
+        "vulnerabilities": [
+          {
+            "name": "CVE-2024-43796",
+            "severity": "LOW",
+            "fixedVersion": "4.20.0",
+            "fileRemediation": null,
+            "source": "https://github.com/advisories/GHSA-qw6h-vgh9-j6wx",
+            "description": "Express.js minimalist web framework for node. In express < 4.20.0, passing untrusted user input - even after sanitizing it - to response.redirect() may execute untrusted code. This issue is patched in express 4.20.0.",
+            "score": 4.7,
+            "exploitabilityScore": 1.6,
+            "cvssV3Metrics": {
+              "attackComplexity": "HIGH",
+              "attackVector": "NETWORK",
+              "confidentialityImpact": "LOW",
+              "integrityImpact": "LOW",
+              "privilegesRequired": "NONE",
+              "userInteractionRequired": true
+            },
+            "cvssV2Metrics": {
+              "attackComplexity": null,
+              "attackVector": null,
+              "confidentialityImpact": null,
+              "integrityImpact": null,
+              "privilegesRequired": null,
+              "userInteractionRequired": false
+            },
+            "cvssV3Vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:C/C:L/I:L/A:N",
+            "cvssV4Vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:P/VC:N/VI:N/VA:N/SC:L/SI:L/SA:L",
+            "hasExploit": false,
+            "hasCisaKevExploit": false,
+            "cisaKevReleaseDate": null,
+            "cisaKevDueDate": null,
+            "epssProbability": 0.1,
+            "epssPercentile": 30.4,
+            "epssSeverity": "LOW",
+            "weightedSeverity": "LOW",
+            "publishDate": "2024-09-10T15:15:00Z",
+            "fixPublishDate": "2024-09-11T04:50:58Z",
+            "gracePeriodEnd": null,
+            "gracePeriodRemainingHours": null,
+            "failedPolicyMatches": null,
+            "finding": {
+              "id": "68bb59ce-2a8c-5c9e-86c1-841954c1baaa"
+            },
+            "ignoredPolicyMatches": null
+          },
+          {
+            "name": "CVE-2024-29041",
+            "severity": "MEDIUM",
+            "fixedVersion": "4.19.2",
+            "fileRemediation": null,
+            "source": "https://github.com/advisories/GHSA-rv95-896h-c2vc",
+            "description": "Express.js minimalist web framework for node. Versions of Express.js prior to 4.19.0 and all pre-release alpha and beta versions of 5.0 are affected by an open redirect vulnerability using malformed URLs. When a user of Express performs a redirect using a user-provided URL Express performs an encode [using `encodeurl`](https://github.com/pillarjs/encodeurl) on the contents before passing it to the `location` header. This can cause malformed URLs to be evaluated in unexpected ways by common redirect allow list implementations in Express applications, leading to an Open Redirect via bypass of a properly implemented allow list. The main method impacted is `res.location()` but this is also called from within `res.redirect()`. The vulnerability is fixed in 4.19.2 and 5.0.0-beta.3.",
+            "score": 6.1,
+            "exploitabilityScore": 2.8,
+            "cvssV3Metrics": {
+              "attackComplexity": "LOW",
+              "attackVector": "NETWORK",
+              "confidentialityImpact": "LOW",
+              "integrityImpact": "LOW",
+              "privilegesRequired": "NONE",
+              "userInteractionRequired": true
+            },
+            "cvssV2Metrics": {
+              "attackComplexity": null,
+              "attackVector": null,
+              "confidentialityImpact": null,
+              "integrityImpact": null,
+              "privilegesRequired": null,
+              "userInteractionRequired": false
+            },
+            "cvssV3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+            "cvssV4Vector": null,
+            "hasExploit": false,
+            "hasCisaKevExploit": false,
+            "cisaKevReleaseDate": null,
+            "cisaKevDueDate": null,
+            "epssProbability": 0.2,
+            "epssPercentile": 35.7,
+            "epssSeverity": "LOW",
+            "weightedSeverity": "LOW",
+            "publishDate": "2024-03-25T21:15:00Z",
+            "fixPublishDate": "2024-03-26T12:34:58Z",
+            "gracePeriodEnd": null,
+            "gracePeriodRemainingHours": null,
+            "failedPolicyMatches": null,
+            "finding": {
+              "id": "e3277b8f-1114-5de5-9aa6-8935994a0d46"
+            },
+            "ignoredPolicyMatches": null
+          }
+        ],
+        "detectionMethod": "LIBRARY",
+        "layerMetadata": null,
+        "failedPolicyMatches": null,
+        "resolvedDependencyTree": null
+      }
+    ],
+    "applications": null,
+    "endOfLifeTechnologies": null,
+    "cpes": null,
+    "secrets": [
+      {
+        "id": "77ac3240-f6f6-59f9-a8d1-efb5e2a4a457",
+        "externalId": "/code##/leaky.env##13",
+        "description": "GitHub Classic PAT in Dedicated Secret Files",
+        "path": "/leaky.env",
+        "lineNumber": 1,
+        "offset": 13,
+        "type": "SAAS_API_KEY",
+        "contains": [
+          {
+            "name": "GitHub Classic PAT",
+            "type": "SAAS_API_KEY"
+          }
+        ],
+        "snippet": "---REDACTED---",
+        "failedPolicyMatches": null,
+        "hasAdminPrivileges": null,
+        "hasHighPrivileges": null,
+        "severity": "INFORMATIONAL",
+        "relatedEntities": null,
+        "ignoredPolicyMatches": [
+          {
+            "policy": {
+              "id": "5e9561cf-2548-4b9f-93ab-0b4056c1fc23",
+              "name": "aai-secrets-default-policy",
+              "description": null,
+              "type": "SECRETS",
+              "builtin": false,
+              "projects": [
+                {
+                  "id": "b4ce9215-eca0-50f1-97b3-6c0224097997"
+                }
+              ],
+              "policyLifecycleEnforcements": [
+                {
+                  "enforcementMethod": "AUDIT",
+                  "deploymentLifecycle": "CLI",
+                  "enforcementConfig": null
+                },
+                {
+                  "enforcementMethod": "AUDIT",
+                  "deploymentLifecycle": "CODE",
+                  "enforcementConfig": null
+                }
+              ],
+              "ignoreRules": null,
+              "lifecycleTargets": [
+                "BUILD",
+                "CODE"
+              ],
+              "Default": false
+            },
+            "ignoreReason": "BELOW_THRESHOLD",
+            "matchedIgnoreRules": null
+          }
+        ],
+        "ruleId": "SECRET-1065",
+        "details": {
+          "__typename": "DiskScanSecretDetailsSaasAPIKey",
+          "serviceName": "GitHub Classic PAT"
+        }
+      }
+    ],
+    "dataFindings": null,
+    "vulnerableSBOMArtifactsByNameVersion": [
+      {
+        "id": "78edddad-d29a-5c02-9a6e-eecbaf3c63f2",
+        "type": {
+          "group": "CODE_LIBRARY",
+          "codeLibraryLanguage": "JAVASCRIPT",
+          "osPackageManager": null,
+          "hostedTechnology": null,
+          "plugin": null,
+          "custom": null,
+          "ciComponent": null
+        },
+        "name": "lodash",
+        "version": "4.17.4",
+        "filePath": "/package-lock.json",
+        "layerMetadata": null,
+        "vulnerabilityFindings": {
+          "severities": {
+            "criticalCount": 1,
+            "highCount": 4,
+            "mediumCount": 5,
+            "lowCount": 0,
+            "infoCount": 0
+          },
+          "fixedVersion": "4.18.0",
+          "remediation": "npm update lodash",
+          "fileRemediation": null,
+          "findings": null
+        }
+      },
+      {
+        "id": "5a21c26a-e1f1-5aec-8dc2-59a98bb5dafb",
+        "type": {
+          "group": "CODE_LIBRARY",
+          "codeLibraryLanguage": "JAVASCRIPT",
+          "osPackageManager": null,
+          "hostedTechnology": null,
+          "plugin": null,
+          "custom": null,
+          "ciComponent": null
+        },
+        "name": "express",
+        "version": "4.16.0",
+        "filePath": "/package-lock.json",
+        "layerMetadata": null,
+        "vulnerabilityFindings": {
+          "severities": {
+            "criticalCount": 0,
+            "highCount": 0,
+            "mediumCount": 1,
+            "lowCount": 1,
+            "infoCount": 0
+          },
+          "fixedVersion": "4.20.0",
+          "remediation": "npm update express",
+          "fileRemediation": null,
+          "findings": null
+        }
+      }
+    ],
+    "hostConfiguration": {
+      "hostConfigurationFrameworks": null,
+      "hostConfigurationFindings": null,
+      "analytics": {
+        "severity": {
+          "infoCount": 0,
+          "lowCount": 0,
+          "mediumCount": 0,
+          "highCount": 0,
+          "criticalCount": 0
+        },
+        "status": {
+          "passCount": 0,
+          "failCount": 0,
+          "errorCount": 0,
+          "notAssessedCount": 0,
+          "totalCount": 0
+        }
+      }
+    },
+    "failedPolicyMatches": null,
+    "analytics": {
+      "vulnerabilities": {
+        "infoCount": 0,
+        "lowCount": 1,
+        "mediumCount": 6,
+        "highCount": 4,
+        "criticalCount": 1,
+        "unfixedCount": 0,
+        "totalCount": 12
+      },
+      "secrets": {
+        "privateKeyCount": 0,
+        "publicKeyCount": 0,
+        "passwordCount": 0,
+        "certificateCount": 0,
+        "cloudKeyCount": 0,
+        "sshAuthorizedKeyCount": 0,
+        "dbConnectionStringCount": 0,
+        "gitCredentialCount": 0,
+        "presignedURLCount": 0,
+        "saasAPIKeyCount": 1,
+        "infoCount": 1,
+        "lowCount": 0,
+        "mediumCount": 0,
+        "highCount": 0,
+        "criticalCount": 0,
+        "totalCount": 1
+      },
+      "hostConfiguration": {
+        "infoCount": 0,
+        "lowCount": 0,
+        "mediumCount": 0,
+        "highCount": 0,
+        "criticalCount": 0
+      },
+      "malware": {
+        "infoCount": 0,
+        "lowCount": 0,
+        "mediumCount": 0,
+        "highCount": 0,
+        "criticalCount": 0,
+        "totalCount": 0
+      },
+      "softwareSupplyChain": {
+        "infoCount": 0,
+        "lowCount": 0,
+        "mediumCount": 0,
+        "highCount": 0,
+        "criticalCount": 0,
+        "totalCount": 0
+      },
+      "aiModel": null,
+      "sast": {
+        "infoCount": 0,
+        "lowCount": 0,
+        "mediumCount": 0,
+        "highCount": 0,
+        "criticalCount": 0,
+        "totalCount": 0
+      },
+      "filesScannedCount": 2,
+      "directoriesScannedCount": 1
+    },
+    "sbomOutput": "",
+    "malwares": null,
+    "softwareSupplyChain": null,
+    "aiModels": null,
+    "sast": null,
+    "iac": null,
+    "ruleMatches": null,
+    "scanStatistics": null,
+    "fileTypes": null,
+    "discoveredResources": null
+  },
+  "reportUrl": "https://app.wiz.io/findings/cicd-scans#~%2528cicd_scan~%25270069faa4-330b-8e5c-932c-970e54148001%252A2c2026-05-06T02%2525%25252A3a15%2525%25252A3a22.245229623Z%2527%2529"
+}

--- a/api/securitytest/wizcli.go
+++ b/api/securitytest/wizcli.go
@@ -1,19 +1,66 @@
 package securitytest
 
 import (
-	"bufio"
+	"encoding/json"
 	"errors"
-	"regexp"
+	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/githubanotaai/huskyci-api/api/types"
 )
 
-var ansiEscape = regexp.MustCompile(`\x1b\[[0-9;]*m|\[[0-9;]*m`)
-var cvePattern = regexp.MustCompile(`CVE-\d{4}-\d+`)
+// wizCLIReport models the subset of `wizcli dir scan -f json` output that
+// huskyCI surfaces as findings. Unrelated metadata (analytics, sbomOutput,
+// hostConfiguration, ...) is intentionally ignored.
+type wizCLIReport struct {
+	Status struct {
+		State   string `json:"state"`
+		Verdict string `json:"verdict"`
+	} `json:"status"`
+	Result struct {
+		Libraries             []wizPackageWithVulns  `json:"libraries"`
+		OSPackages            []wizPackageWithVulns  `json:"osPackages"`
+		Secrets               []wizSecretFinding     `json:"secrets"`
+		DataFindings          []wizDataFinding       `json:"dataFindings"`
+		EndOfLifeTechnologies []wizEndOfLifeFinding  `json:"endOfLifeTechnologies"`
+	} `json:"result"`
+}
 
-func stripAnsiWiz(s string) string {
-	return ansiEscape.ReplaceAllString(s, "")
+type wizPackageWithVulns struct {
+	Name            string             `json:"name"`
+	Version         string             `json:"version"`
+	Path            string             `json:"path"`
+	StartLine       int                `json:"startLine"`
+	Vulnerabilities []wizVulnerability `json:"vulnerabilities"`
+}
+
+type wizVulnerability struct {
+	Name         string `json:"name"`
+	Severity     string `json:"severity"`
+	FixedVersion string `json:"fixedVersion"`
+	Description  string `json:"description"`
+	HasExploit   bool   `json:"hasExploit"`
+}
+
+type wizSecretFinding struct {
+	Description string `json:"description"`
+	Path        string `json:"path"`
+	LineNumber  int    `json:"lineNumber"`
+	Severity    string `json:"severity"`
+	Type        string `json:"type"`
+}
+
+type wizDataFinding struct {
+	Classifier string `json:"classifier"`
+	MatchCount int    `json:"matchCount"`
+	Severity   string `json:"severity"`
+	Path       string `json:"path"`
+}
+
+type wizEndOfLifeFinding struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
 }
 
 func analyzeWizCLI(scanInfo *SecTestScanInfo) error {
@@ -29,7 +76,16 @@ func analyzeWizCLI(scanInfo *SecTestScanInfo) error {
 		return scanInfo.ErrorFound
 	}
 
-	vulns := parseWizCLIStdout(output)
+	trimmed := strings.TrimSpace(output)
+	if trimmed == "" {
+		return nil
+	}
+
+	vulns, err := parseWizCLIJSON(trimmed)
+	if err != nil {
+		scanInfo.ErrorFound = fmt.Errorf("wizcli json parse failed: %w", err)
+		return scanInfo.ErrorFound
+	}
 
 	for _, v := range vulns {
 		switch strings.ToUpper(v.Severity) {
@@ -47,49 +103,27 @@ func analyzeWizCLI(scanInfo *SecTestScanInfo) error {
 	return nil
 }
 
-// parseWizCLIStdout parses the textual stdout of `wizcli dir scan` into
-// HuskyCIVulnerability entries. It mirrors the logic in console-parser.js,
-// handling Secrets, Data Findings, and CVE sections.
-func parseWizCLIStdout(output string) []types.HuskyCIVulnerability {
+// parseWizCLIJSON converts the JSON produced by `wizcli dir scan -f json`
+// into HuskyCIVulnerability entries, covering CVEs (libraries, OS packages),
+// secrets, data findings, and end-of-life technologies.
+func parseWizCLIJSON(output string) ([]types.HuskyCIVulnerability, error) {
+	var report wizCLIReport
+	if err := json.Unmarshal([]byte(output), &report); err != nil {
+		return nil, err
+	}
+
 	var findings []types.HuskyCIVulnerability
 	seen := make(map[string]bool)
 
-	type secretState struct {
-		description string
-		severity    string
-		filePath    string
-		lineNumber  string
-	}
-
-	type dataFindingState struct {
-		classifier string
-		matchCount string
-		severity   string
-		filePath   string
-	}
-
-	type cveState struct {
-		cve          string
-		severity     string
-		location     string
-		fixedVersion string
-	}
-
-	type packageState struct {
-		name    string
-		version string
-		path    string
-	}
-
-	addFinding := func(title, severity, file, line, details, tool string) {
-		key := title + "::" + severity + "::" + file
+	addFinding := func(title, severity, file, line, details string) {
+		key := title + "::" + severity + "::" + file + "::" + line
 		if seen[key] {
 			return
 		}
 		seen[key] = true
 		findings = append(findings, types.HuskyCIVulnerability{
 			Language:     "Generic",
-			SecurityTool: tool,
+			SecurityTool: "WizCLI",
 			Severity:     severity,
 			Title:        title,
 			File:         file,
@@ -98,250 +132,84 @@ func parseWizCLIStdout(output string) []types.HuskyCIVulnerability {
 		})
 	}
 
-	var (
-		currentSection     string
-		currentSecret      *secretState
-		currentDataFinding *dataFindingState
-		currentCVE         *cveState
-		currentPackage     *packageState
-	)
-
-	flushCVE := func(cve *cveState) {
-		if cve == nil {
-			return
-		}
-		fv := cve.fixedVersion
-		if fv == "" {
-			fv = "n/a"
-		}
-		details := cve.cve
-		if fv != "n/a" {
-			details += " (fixed: " + fv + ")"
-		}
-		addFinding(cve.cve, cve.severity, cve.location, "", details, "WizCLI")
-	}
-
-	flushSecret := func(s *secretState) {
-		if s == nil || s.filePath == "" {
-			return
-		}
-		loc := s.filePath
-		if s.lineNumber != "" {
-			loc += ", Line " + s.lineNumber
-		}
-		sev := s.severity
-		if sev == "" {
-			sev = "INFO"
-		}
-		addFinding(s.description, sev, loc, s.lineNumber, s.description, "WizCLI")
-	}
-
-	scanner := bufio.NewScanner(strings.NewReader(output))
-	var lines []string
-	for scanner.Scan() {
-		lines = append(lines, scanner.Text())
-	}
-
-	for i, rawLine := range lines {
-		line := strings.TrimSpace(stripAnsiWiz(rawLine))
-
-		// Section detection
-		if strings.Contains(line, "Library vulnerabilities:") || strings.Contains(line, "OS Package vulnerabilities:") {
-			flushCVE(currentCVE)
-			currentCVE = nil
-			currentSection = "vulnerabilities"
-			currentPackage = nil
-			continue
-		}
-		if strings.Contains(line, "Secrets:") {
-			currentSection = "secrets"
-			currentSecret = nil
-			continue
-		}
-		if strings.Contains(line, "Data Findings:") || strings.Contains(line, "Data findings:") {
-			currentSection = "dataFindings"
-			currentDataFinding = nil
-			continue
-		}
-		if strings.Contains(line, "End of life technologies:") {
-			flushCVE(currentCVE)
-			currentCVE = nil
-			currentSection = "eol"
-			currentPackage = nil
-			continue
-		}
-		if strings.Contains(line, "Licenses:") {
-			flushCVE(currentCVE)
-			currentCVE = nil
-			currentSection = "licenses"
-			currentPackage = nil
-			continue
-		}
-
-		switch currentSection {
-
-		case "secrets":
-			cleanLine := stripAnsiWiz(rawLine)
-
-			if strings.Contains(line, "Secret description:") {
-				flushSecret(currentSecret)
-				re := regexp.MustCompile(`(?i)Secret description:\s*(.+?)(?:\s*\[0m|\s*\[[0-9;]*m|\s*$)`)
-				if m := re.FindStringSubmatch(cleanLine); len(m) > 1 {
-					desc := ansiEscape.ReplaceAllString(strings.TrimSpace(m[1]), "")
-					currentSecret = &secretState{description: desc, severity: "INFO"}
-				}
-				continue
+	collectCVEs := func(pkgs []wizPackageWithVulns) {
+		for _, pkg := range pkgs {
+			location := pkg.Name
+			if pkg.Version != "" {
+				location += ":" + pkg.Version
 			}
-			if currentSecret != nil && strings.Contains(line, "Severity:") {
-				cleanedLine := ansiEscape.ReplaceAllString(cleanLine, "")
-				if m := regexp.MustCompile(`(?i)Severity:\s*(\w+)`).FindStringSubmatch(cleanedLine); len(m) > 1 {
-					currentSecret.severity = strings.ToUpper(strings.TrimSpace(m[1]))
-				}
-				if currentSecret.filePath != "" {
-					flushSecret(currentSecret)
-					currentSecret = nil
-				}
-				continue
+			if pkg.Path != "" {
+				location += " (" + strings.TrimLeft(pkg.Path, "/") + ")"
 			}
-			if currentSecret != nil && strings.Contains(line, "Path:") {
-				re := regexp.MustCompile(`(?i)Path:\s*([^,]+)(?:,\s*Line\s+(\d+))?`)
-				if m := re.FindStringSubmatch(cleanLine); len(m) > 1 {
-					fp := ansiEscape.ReplaceAllString(strings.TrimSpace(m[1]), "")
-					currentSecret.filePath = fp
-					if len(m) > 2 && m[2] != "" {
-						currentSecret.lineNumber = strings.TrimSpace(m[2])
-					} else if i+1 < len(lines) {
-						nextLine := strings.TrimSpace(stripAnsiWiz(lines[i+1]))
-						if lm := regexp.MustCompile(`(?i)Line\s+(\d+)`).FindStringSubmatch(nextLine); len(lm) > 1 {
-							currentSecret.lineNumber = lm[1]
-						}
-					}
-					if currentSecret.severity != "" && currentSecret.severity != "INFO" {
-						flushSecret(currentSecret)
-						currentSecret = nil
-					}
-				}
-				continue
+			line := ""
+			if pkg.StartLine > 0 {
+				line = strconv.Itoa(pkg.StartLine)
 			}
-
-		case "dataFindings":
-			cleanLine := stripAnsiWiz(line)
-			if strings.Contains(line, "Data finding for classifier:") {
-				re := regexp.MustCompile(`(?i)Data finding for classifier:\s*(.+?)(?:\s*\[0m|\s*\[[0-9;]*m|\s*$)`)
-				if m := re.FindStringSubmatch(cleanLine); len(m) > 1 {
-					clf := ansiEscape.ReplaceAllString(strings.TrimSpace(m[1]), "")
-					currentDataFinding = &dataFindingState{classifier: clf, severity: "INFO"}
+			for _, v := range pkg.Vulnerabilities {
+				if v.Name == "" {
+					continue
 				}
-				continue
-			}
-			if currentDataFinding != nil && strings.Contains(line, "Match count:") {
-				if m := regexp.MustCompile(`(?i)Match count:\s*(\d+)`).FindStringSubmatch(cleanLine); len(m) > 1 {
-					currentDataFinding.matchCount = m[1]
+				details := v.Name
+				if v.FixedVersion != "" {
+					details += " (fixed: " + v.FixedVersion + ")"
+				} else {
+					details += " (fixed: n/a)"
 				}
-				continue
-			}
-			if currentDataFinding != nil && strings.Contains(line, "Severity:") {
-				cleanedLine := ansiEscape.ReplaceAllString(cleanLine, "")
-				if m := regexp.MustCompile(`(?i)Severity:\s*(\w+)`).FindStringSubmatch(cleanedLine); len(m) > 1 {
-					currentDataFinding.severity = strings.ToUpper(strings.TrimSpace(m[1]))
+				if v.Description != "" {
+					details += " — " + v.Description
 				}
-				continue
-			}
-			if currentDataFinding != nil && strings.Contains(line, "Path:") {
-				if m := regexp.MustCompile(`(?i)Path:\s*(.+)`).FindStringSubmatch(cleanLine); len(m) > 1 {
-					fp := strings.TrimSpace(m[1])
-					if currentDataFinding.filePath == "" {
-						currentDataFinding.filePath = fp
-						name := currentDataFinding.classifier
-						if currentDataFinding.matchCount != "" {
-							name += " (" + currentDataFinding.matchCount + " matches)"
-						}
-						addFinding(name, currentDataFinding.severity, fp, "", name, "WizCLI")
-					}
-				}
-				continue
-			}
-
-		case "vulnerabilities":
-			cleanLine := stripAnsiWiz(rawLine)
-			if strings.Contains(line, "Name:") {
-				flushCVE(currentCVE)
-				currentCVE = nil
-				nameRe := regexp.MustCompile(`Name:\s*([^,]+)`)
-				verRe := regexp.MustCompile(`Version:\s*([^,]+)`)
-				pathRe := regexp.MustCompile(`Path:\s*(.+?)(?:\s*$)`)
-				var pkg packageState
-				if m := nameRe.FindStringSubmatch(cleanLine); len(m) > 1 {
-					pkg.name = strings.TrimSpace(m[1])
-				}
-				if m := verRe.FindStringSubmatch(cleanLine); len(m) > 1 {
-					pkg.version = strings.TrimSpace(m[1])
-				}
-				if m := pathRe.FindStringSubmatch(cleanLine); len(m) > 1 {
-					p := strings.TrimSpace(m[1])
-					if idx := strings.Index(p, " contains transitive"); idx != -1 {
-						p = strings.TrimSpace(p[:idx])
-					}
-					pkg.path = p
-				}
-				if pkg.name != "" {
-					currentPackage = &pkg
-				}
-				continue
-			}
-			if currentPackage != nil && cvePattern.MatchString(line) {
-				flushCVE(currentCVE)
-				cveM := cvePattern.FindString(stripAnsiWiz(rawLine))
-				sevM := regexp.MustCompile(`(?i)Severity:\s*(\w+)`).FindStringSubmatch(stripAnsiWiz(rawLine))
-				sev := "UNKNOWN"
-				if len(sevM) > 1 {
-					sev = strings.ToUpper(strings.TrimSpace(sevM[1]))
-				}
-				loc := currentPackage.name
-				if currentPackage.version != "" {
-					loc += ":" + currentPackage.version
-				}
-				if currentPackage.path != "" {
-					loc += " (" + strings.TrimLeft(currentPackage.path, "/") + ")"
-				}
-				currentCVE = &cveState{cve: cveM, severity: sev, location: loc, fixedVersion: "n/a"}
-				continue
-			}
-			if currentCVE != nil && strings.Contains(line, "Fixed version:") {
-				if m := regexp.MustCompile(`(?i)Fixed version:\s*([^\s,]+)`).FindStringSubmatch(stripAnsiWiz(rawLine)); len(m) > 1 {
-					currentCVE.fixedVersion = strings.TrimSpace(m[1])
-				}
-				continue
-			}
-
-		case "eol":
-			cleanLine := stripAnsiWiz(rawLine)
-			if strings.Contains(line, "Name:") {
-				nameRe := regexp.MustCompile(`Name:\s*([^,]+)`)
-				verRe := regexp.MustCompile(`Version:\s*([^,]+)`)
-				name := ""
-				version := ""
-				if m := nameRe.FindStringSubmatch(cleanLine); len(m) > 1 {
-					name = strings.TrimSpace(m[1])
-				}
-				if m := verRe.FindStringSubmatch(cleanLine); len(m) > 1 {
-					version = strings.TrimSpace(m[1])
-				}
-				if name != "" {
-					loc := name
-					if version != "" {
-						loc += ":" + version
-					}
-					addFinding("End of Life Technology", "MEDIUM", loc, "", name+" is end of life", "WizCLI")
-				}
-				continue
+				addFinding(v.Name, strings.ToUpper(v.Severity), location, line, details)
 			}
 		}
 	}
 
-	// Flush any pending state
-	flushCVE(currentCVE)
-	flushSecret(currentSecret)
+	collectCVEs(report.Result.Libraries)
+	collectCVEs(report.Result.OSPackages)
 
-	return findings
+	for _, s := range report.Result.Secrets {
+		title := s.Description
+		if title == "" {
+			title = s.Type
+		}
+		if title == "" {
+			title = "Secret finding"
+		}
+		line := ""
+		if s.LineNumber > 0 {
+			line = strconv.Itoa(s.LineNumber)
+		}
+		severity := strings.ToUpper(s.Severity)
+		if severity == "INFORMATIONAL" || severity == "INFO" || severity == "" {
+			severity = "INFO"
+		}
+		addFinding(title, severity, s.Path, line, title)
+	}
+
+	for _, df := range report.Result.DataFindings {
+		title := df.Classifier
+		if title == "" {
+			title = "Data finding"
+		}
+		if df.MatchCount > 0 {
+			title += " (" + strconv.Itoa(df.MatchCount) + " matches)"
+		}
+		severity := strings.ToUpper(df.Severity)
+		if severity == "INFORMATIONAL" || severity == "INFO" || severity == "" {
+			severity = "INFO"
+		}
+		addFinding(title, severity, df.Path, "", title)
+	}
+
+	for _, eol := range report.Result.EndOfLifeTechnologies {
+		if eol.Name == "" {
+			continue
+		}
+		location := eol.Name
+		if eol.Version != "" {
+			location += ":" + eol.Version
+		}
+		addFinding("End of Life Technology", "MEDIUM", location, "", eol.Name+" is end of life")
+	}
+
+	return findings, nil
 }

--- a/api/securitytest/wizcli_test.go
+++ b/api/securitytest/wizcli_test.go
@@ -1,6 +1,8 @@
 package securitytest
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -9,292 +11,227 @@ import (
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
-func findVuln(vulns []types.HuskyCIVulnerability, title string) *types.HuskyCIVulnerability {
+func findVuln(vulns []types.HuskyCIVulnerability, predicate func(types.HuskyCIVulnerability) bool) *types.HuskyCIVulnerability {
 	for i := range vulns {
-		if vulns[i].Title == title {
+		if predicate(vulns[i]) {
 			return &vulns[i]
 		}
 	}
 	return nil
 }
 
-// ── fixtures ─────────────────────────────────────────────────────────────────
+func loadJSONFixture(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join("testdata", "wizcli_v1_json_sample.json")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read fixture %s: %v", path, err)
+	}
+	return string(b)
+}
 
-const secretsFixture = `Secrets:
-  Secret description: AWS Access Key
-  Severity: HIGH
-  Path: ./code/config/settings.py, Line 42
+// ── parser tests ─────────────────────────────────────────────────────────────
 
-  Secret description: Generic API Key
-  Severity: MEDIUM
-  Path: ./code/src/client.go
-`
-
-const dataFindingsFixture = `Data Findings:
-  Data finding for classifier: Email Address
-  Match count: 3
-  Severity: LOW
-  Path: ./code/data/users.csv
-`
-
-const cvesFixture = `Library vulnerabilities:
-  Name: lodash, Version: 4.17.15, Path: package-lock.json
-    CVE-2021-23337 Severity: HIGH
-    Fixed version: 4.17.21
-`
-
-const eolFixture = `End of life technologies:
-  Name: Python, Version: 2.7
-`
-
-const ansiFixture = "Secrets:\n  Secret description: \x1b[31mAWS Access Key\x1b[0m\n  Severity: HIGH\n  Path: ./code/config/aws.yaml, Line 10\n"
-
-const mixedFixture = `Secrets:
-  Secret description: AWS Access Key
-  Severity: HIGH
-  Path: ./code/config/settings.py, Line 42
-
-Library vulnerabilities:
-  Name: lodash, Version: 4.17.15, Path: package-lock.json
-    CVE-2021-23337 Severity: HIGH
-    Fixed version: 4.17.21
-`
-
-// ── TestParseWizCLIStdout_Empty ───────────────────────────────────────────────
-
-func TestParseWizCLIStdout_Empty(t *testing.T) {
-	result := parseWizCLIStdout("")
-	if len(result) != 0 {
-		t.Errorf("expected empty slice, got %d findings", len(result))
+func TestParseWizCLIJSON_Empty(t *testing.T) {
+	_, err := parseWizCLIJSON("")
+	if err == nil {
+		t.Error("expected error parsing empty JSON, got nil")
 	}
 }
 
-// ── TestParseWizCLIStdout_Secrets ────────────────────────────────────────────
-
-func TestParseWizCLIStdout_Secrets(t *testing.T) {
-	result := parseWizCLIStdout(secretsFixture)
-	if len(result) == 0 {
-		t.Fatal("expected findings from Secrets section, got none")
-	}
-
-	awsKey := findVuln(result, "AWS Access Key")
-	if awsKey == nil {
-		t.Fatal("expected finding with Title 'AWS Access Key'")
-	}
-	if awsKey.Severity != "HIGH" {
-		t.Errorf("expected severity HIGH, got %s", awsKey.Severity)
-	}
-	if !strings.Contains(awsKey.File, "settings.py") {
-		t.Errorf("expected file to contain 'settings.py', got %s", awsKey.File)
-	}
-
-	genericKey := findVuln(result, "Generic API Key")
-	if genericKey == nil {
-		t.Fatal("expected finding with Title 'Generic API Key'")
-	}
-	if genericKey.Severity != "MEDIUM" {
-		t.Errorf("expected severity MEDIUM, got %s", genericKey.Severity)
-	}
-	if !strings.Contains(genericKey.File, "client.go") {
-		t.Errorf("expected file to contain 'client.go', got %s", genericKey.File)
+func TestParseWizCLIJSON_InvalidJSON(t *testing.T) {
+	_, err := parseWizCLIJSON("not json")
+	if err == nil {
+		t.Error("expected error parsing invalid JSON, got nil")
 	}
 }
 
-// ── TestParseWizCLIStdout_DataFindings ───────────────────────────────────────
-
-func TestParseWizCLIStdout_DataFindings(t *testing.T) {
-	result := parseWizCLIStdout(dataFindingsFixture)
-	if len(result) == 0 {
-		t.Fatal("expected findings from Data Findings section, got none")
+func TestParseWizCLIJSON_NoFindings(t *testing.T) {
+	out, err := parseWizCLIJSON(`{"status":{"state":"SUCCESS","verdict":"PASSED_BY_POLICY"},"result":{}}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-
-	var emailFinding *types.HuskyCIVulnerability
-	for i := range result {
-		if strings.Contains(result[i].Title, "Email Address") {
-			emailFinding = &result[i]
-			break
-		}
-	}
-	if emailFinding == nil {
-		t.Fatal("expected finding containing 'Email Address'")
-	}
-	if emailFinding.Severity != "LOW" {
-		t.Errorf("expected severity LOW, got %s", emailFinding.Severity)
-	}
-	if !strings.Contains(emailFinding.File, "users.csv") {
-		t.Errorf("expected file to contain 'users.csv', got %s", emailFinding.File)
+	if len(out) != 0 {
+		t.Errorf("expected zero findings, got %d", len(out))
 	}
 }
 
-// ── TestParseWizCLIStdout_CVEs ────────────────────────────────────────────────
-
-func TestParseWizCLIStdout_CVEs(t *testing.T) {
-	result := parseWizCLIStdout(cvesFixture)
-	if len(result) == 0 {
-		t.Fatal("expected CVE findings, got none")
+func TestParseWizCLIJSON_LibraryCVEs(t *testing.T) {
+	const input = `{"status":{"state":"SUCCESS","verdict":"PASSED_BY_POLICY"},"result":{"libraries":[
+		{"name":"lodash","version":"4.17.4","path":"/package-lock.json","startLine":5,"endLine":5,
+		 "vulnerabilities":[
+		   {"name":"CVE-2021-23337","severity":"HIGH","fixedVersion":"4.17.21"},
+		   {"name":"CVE-2018-3721","severity":"MEDIUM","fixedVersion":"4.17.5"}
+		 ]}
+	]}}`
+	out, err := parseWizCLIJSON(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-
-	var cveFinding *types.HuskyCIVulnerability
-	for i := range result {
-		if strings.Contains(result[i].Title, "CVE-2021-23337") {
-			cveFinding = &result[i]
-			break
-		}
+	if len(out) != 2 {
+		t.Fatalf("expected 2 findings, got %d", len(out))
 	}
-	if cveFinding == nil {
-		t.Fatal("expected finding containing 'CVE-2021-23337'")
+	high := findVuln(out, func(v types.HuskyCIVulnerability) bool {
+		return v.Title == "CVE-2021-23337"
+	})
+	if high == nil {
+		t.Fatal("expected CVE-2021-23337 finding")
 	}
-	if cveFinding.Severity != "HIGH" {
-		t.Errorf("expected severity HIGH, got %s", cveFinding.Severity)
+	if high.Severity != "HIGH" {
+		t.Errorf("expected severity HIGH, got %q", high.Severity)
 	}
-	if !strings.Contains(cveFinding.File, "lodash") {
-		t.Errorf("expected file/location to contain 'lodash', got %s", cveFinding.File)
+	if !strings.Contains(high.File, "lodash:4.17.4") {
+		t.Errorf("expected location to contain 'lodash:4.17.4', got %q", high.File)
 	}
-}
-
-// ── TestParseWizCLIStdout_EOL ─────────────────────────────────────────────────
-
-func TestParseWizCLIStdout_EOL(t *testing.T) {
-	result := parseWizCLIStdout(eolFixture)
-	if len(result) == 0 {
-		t.Fatal("expected EOL findings, got none")
+	if high.Line != "5" {
+		t.Errorf("expected line '5', got %q", high.Line)
 	}
-
-	var eolFinding *types.HuskyCIVulnerability
-	for i := range result {
-		if result[i].Title == "End of Life Technology" {
-			eolFinding = &result[i]
-			break
-		}
+	if !strings.Contains(high.Details, "fixed: 4.17.21") {
+		t.Errorf("expected details to mention fixed version, got %q", high.Details)
 	}
-	if eolFinding == nil {
-		t.Fatal("expected finding with Title 'End of Life Technology'")
-	}
-	if eolFinding.Severity != "MEDIUM" {
-		t.Errorf("expected severity MEDIUM, got %s", eolFinding.Severity)
-	}
-	if !strings.Contains(eolFinding.File, "Python") {
-		t.Errorf("expected file/location to contain 'Python', got %s", eolFinding.File)
+	if high.SecurityTool != "WizCLI" {
+		t.Errorf("expected tool WizCLI, got %q", high.SecurityTool)
 	}
 }
 
-// ── TestParseWizCLIStdout_AnsiStripping ──────────────────────────────────────
-
-func TestParseWizCLIStdout_AnsiStripping(t *testing.T) {
-	result := parseWizCLIStdout(ansiFixture)
-	if len(result) == 0 {
-		t.Fatal("expected findings from ANSI fixture, got none")
+func TestParseWizCLIJSON_OSPackagesUseSamePath(t *testing.T) {
+	const input = `{"result":{"osPackages":[
+		{"name":"openssl","version":"1.1.1","path":"/usr/lib","vulnerabilities":[
+			{"name":"CVE-2024-0001","severity":"CRITICAL"}
+		]}
+	]}}`
+	out, err := parseWizCLIJSON(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-
-	for _, v := range result {
-		if strings.Contains(v.Title, "\x1b") {
-			t.Errorf("ANSI escape code not stripped from Title: %q", v.Title)
-		}
-		if strings.Contains(v.File, "\x1b") {
-			t.Errorf("ANSI escape code not stripped from File: %q", v.File)
-		}
+	if len(out) != 1 || out[0].Title != "CVE-2024-0001" {
+		t.Fatalf("expected one CVE-2024-0001 finding, got %+v", out)
 	}
-
-	awsKey := findVuln(result, "AWS Access Key")
-	if awsKey == nil {
-		t.Fatal("expected finding with Title 'AWS Access Key' after ANSI stripping")
-	}
-	if awsKey.Severity != "HIGH" {
-		t.Errorf("expected severity HIGH, got %s", awsKey.Severity)
+	if out[0].Severity != "CRITICAL" {
+		t.Errorf("expected CRITICAL severity, got %q", out[0].Severity)
 	}
 }
 
-// ── TestParseWizCLIStdout_MixedSections ──────────────────────────────────────
-
-func TestParseWizCLIStdout_MixedSections(t *testing.T) {
-	result := parseWizCLIStdout(mixedFixture)
-
-	hasSecret := false
-	hasCVE := false
-	for _, v := range result {
-		if v.Title == "AWS Access Key" {
-			hasSecret = true
-		}
-		if strings.Contains(v.Title, "CVE-2021-23337") {
-			hasCVE = true
-		}
+func TestParseWizCLIJSON_Secrets(t *testing.T) {
+	const input = `{"result":{"secrets":[
+		{"description":"GitHub Classic PAT","path":"/leaky.env","lineNumber":1,"severity":"HIGH","type":"SAAS_API_KEY"},
+		{"description":"AWS access key","path":"/cfg.yaml","lineNumber":42,"severity":"INFORMATIONAL","type":"GENERIC"}
+	]}}`
+	out, err := parseWizCLIJSON(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if !hasSecret {
-		t.Error("expected secret finding in mixed output")
+	if len(out) != 2 {
+		t.Fatalf("expected 2 secret findings, got %d", len(out))
 	}
-	if !hasCVE {
-		t.Error("expected CVE finding in mixed output")
+	pat := findVuln(out, func(v types.HuskyCIVulnerability) bool {
+		return v.Title == "GitHub Classic PAT"
+	})
+	if pat == nil || pat.Severity != "HIGH" || pat.Line != "1" {
+		t.Errorf("unexpected PAT finding: %+v", pat)
+	}
+	info := findVuln(out, func(v types.HuskyCIVulnerability) bool {
+		return v.Title == "AWS access key"
+	})
+	if info == nil || info.Severity != "INFO" {
+		t.Errorf("expected INFORMATIONAL secret to bucket as INFO, got %+v", info)
 	}
 }
 
-// ── TestAnalyzeWizCLI_SeverityBuckets ────────────────────────────────────────
+func TestParseWizCLIJSON_DataFindings(t *testing.T) {
+	const input = `{"result":{"dataFindings":[
+		{"classifier":"Email Address","matchCount":3,"severity":"LOW","path":"/users.csv"}
+	]}}`
+	out, err := parseWizCLIJSON(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("expected 1 data finding, got %d", len(out))
+	}
+	if !strings.Contains(out[0].Title, "Email Address") || !strings.Contains(out[0].Title, "3 matches") {
+		t.Errorf("expected title to mention classifier+count, got %q", out[0].Title)
+	}
+	if out[0].Severity != "LOW" {
+		t.Errorf("expected LOW severity, got %q", out[0].Severity)
+	}
+}
 
-func TestAnalyzeWizCLI_SeverityBuckets(t *testing.T) {
-	const input = `Secrets:
-  Secret description: High Secret
-  Severity: HIGH
-  Path: ./high.py
+func TestParseWizCLIJSON_EOLTechnologies(t *testing.T) {
+	const input = `{"result":{"endOfLifeTechnologies":[{"name":"Python","version":"2.7"}]}}`
+	out, err := parseWizCLIJSON(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("expected 1 EOL finding, got %d", len(out))
+	}
+	if out[0].Title != "End of Life Technology" {
+		t.Errorf("expected EOL title, got %q", out[0].Title)
+	}
+	if out[0].Severity != "MEDIUM" {
+		t.Errorf("expected MEDIUM severity, got %q", out[0].Severity)
+	}
+	if !strings.Contains(out[0].File, "Python:2.7") {
+		t.Errorf("expected location to contain 'Python:2.7', got %q", out[0].File)
+	}
+}
 
-  Secret description: Medium Secret
-  Severity: MEDIUM
-  Path: ./medium.py
+func TestParseWizCLIJSON_Deduplicates(t *testing.T) {
+	const input = `{"result":{"libraries":[
+		{"name":"lodash","version":"4.17.4","path":"/package-lock.json",
+		 "vulnerabilities":[
+		   {"name":"CVE-2021-23337","severity":"HIGH","fixedVersion":"4.17.21"},
+		   {"name":"CVE-2021-23337","severity":"HIGH","fixedVersion":"4.17.21"}
+		 ]}
+	]}}`
+	out, err := parseWizCLIJSON(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("expected dedup to 1 finding, got %d", len(out))
+	}
+}
 
-  Secret description: Low Secret
-  Severity: LOW
-  Path: ./low.py
+// ── analyzeWizCLI tests ──────────────────────────────────────────────────────
 
-  Secret description: Info Note
-  Severity: INFO
-  Path: ./info.py
-`
+func TestAnalyzeWizCLI_RealJSONFixture_BucketsAllSeverities(t *testing.T) {
 	scanInfo := &SecTestScanInfo{}
-	scanInfo.Container.COutput = input
+	scanInfo.Container.COutput = loadJSONFixture(t)
 
 	if err := analyzeWizCLI(scanInfo); err != nil {
 		t.Fatalf("analyzeWizCLI returned unexpected error: %v", err)
 	}
 
-	if len(scanInfo.Vulnerabilities.HighVulns) == 0 {
-		t.Error("expected at least one HIGH vuln")
+	high := len(scanInfo.Vulnerabilities.HighVulns)
+	med := len(scanInfo.Vulnerabilities.MediumVulns)
+	low := len(scanInfo.Vulnerabilities.LowVulns)
+	info := len(scanInfo.Vulnerabilities.NoSecVulns)
+	total := high + med + low + info
+
+	if total < 12 {
+		t.Errorf("expected at least 12 findings from fixture (12 lib CVEs + 1 secret), got %d (high=%d med=%d low=%d info=%d)",
+			total, high, med, low, info)
 	}
-	if len(scanInfo.Vulnerabilities.MediumVulns) == 0 {
-		t.Error("expected at least one MEDIUM vuln")
+	if high == 0 {
+		t.Error("expected HIGH-severity library CVEs from fixture")
 	}
-	if len(scanInfo.Vulnerabilities.LowVulns) == 0 {
-		t.Error("expected at least one LOW vuln")
-	}
-	if len(scanInfo.Vulnerabilities.NoSecVulns) == 0 {
-		t.Error("expected at least one INFO/NoSec vuln")
+	if med == 0 {
+		t.Error("expected MEDIUM-severity library CVEs from fixture")
 	}
 
+	// Ensure every finding is tagged WizCLI.
 	for _, v := range scanInfo.Vulnerabilities.HighVulns {
-		sev := strings.ToUpper(v.Severity)
-		if sev != "HIGH" && sev != "CRITICAL" {
-			t.Errorf("unexpected severity in HighVulns: %s", v.Severity)
-		}
-	}
-	for _, v := range scanInfo.Vulnerabilities.MediumVulns {
-		sev := strings.ToUpper(v.Severity)
-		if sev != "MEDIUM" && sev != "MAJOR" {
-			t.Errorf("unexpected severity in MediumVulns: %s", v.Severity)
-		}
-	}
-	for _, v := range scanInfo.Vulnerabilities.LowVulns {
-		sev := strings.ToUpper(v.Severity)
-		if sev != "LOW" && sev != "MINOR" {
-			t.Errorf("unexpected severity in LowVulns: %s", v.Severity)
+		if v.SecurityTool != "WizCLI" {
+			t.Errorf("expected SecurityTool=WizCLI, got %q", v.SecurityTool)
 		}
 	}
 }
 
-// ── TestAnalyzeWizCLI_ErrorAuth ───────────────────────────────────────────────
-
-// TestAnalyzeWizCLI_ErrorAuth verifies that ERROR_AUTH_WIZCLI surfaces as an
-// error so authentication failures are not silently swallowed.
 func TestAnalyzeWizCLI_ErrorAuth(t *testing.T) {
 	scanInfo := &SecTestScanInfo{}
 	scanInfo.Container.COutput = "ERROR_AUTH_WIZCLI: authentication failed"
-	scanInfo.ErrorFound = nil
 
 	err := analyzeWizCLI(scanInfo)
 	if err == nil {
@@ -303,19 +240,8 @@ func TestAnalyzeWizCLI_ErrorAuth(t *testing.T) {
 	if scanInfo.ErrorFound == nil {
 		t.Error("expected scanInfo.ErrorFound to be set, got nil")
 	}
-
-	total := len(scanInfo.Vulnerabilities.HighVulns) +
-		len(scanInfo.Vulnerabilities.MediumVulns) +
-		len(scanInfo.Vulnerabilities.LowVulns) +
-		len(scanInfo.Vulnerabilities.NoSecVulns)
-	if total != 0 {
-		t.Errorf("expected zero vulns on auth error, got %d", total)
-	}
 }
 
-// ── TestAnalyzeWizCLI_ScanError ───────────────────────────────────────────────
-
-// TestAnalyzeWizCLI_ScanError verifies that ERROR_RUNNING_WIZCLI_SCAN surfaces as an error.
 func TestAnalyzeWizCLI_ScanError(t *testing.T) {
 	scanInfo := &SecTestScanInfo{}
 	scanInfo.Container.COutput = "some partial output\nERROR_RUNNING_WIZCLI_SCAN\n"
@@ -329,27 +255,32 @@ func TestAnalyzeWizCLI_ScanError(t *testing.T) {
 	}
 }
 
-// ── TestAnalyzeWizCLI_FindingsNoSentinel ─────────────────────────────────────
-
-// TestAnalyzeWizCLI_FindingsNoSentinel verifies that a normal findings output
-// (exit code 1 scenario) does NOT produce an error — only classified vulns.
-func TestAnalyzeWizCLI_FindingsNoSentinel(t *testing.T) {
-	const input = `Secrets:
-  Secret description: AWS Key
-  Severity: HIGH
-  Path: ./code/.env
-`
+func TestAnalyzeWizCLI_InvalidJSONIsError(t *testing.T) {
 	scanInfo := &SecTestScanInfo{}
-	scanInfo.Container.COutput = input
+	scanInfo.Container.COutput = "this is not json at all"
+
+	err := analyzeWizCLI(scanInfo)
+	if err == nil {
+		t.Fatal("expected non-nil error for non-JSON output, got nil")
+	}
+	if scanInfo.ErrorFound == nil {
+		t.Error("expected scanInfo.ErrorFound to be set, got nil")
+	}
+}
+
+func TestAnalyzeWizCLI_EmptyOutputIsNoFindings(t *testing.T) {
+	scanInfo := &SecTestScanInfo{}
+	scanInfo.Container.COutput = ""
 
 	err := analyzeWizCLI(scanInfo)
 	if err != nil {
-		t.Fatalf("expected nil error for findings-only output, got: %v", err)
+		t.Fatalf("expected nil error for empty output, got %v", err)
 	}
-	if scanInfo.ErrorFound != nil {
-		t.Errorf("expected scanInfo.ErrorFound to be nil, got: %v", scanInfo.ErrorFound)
-	}
-	if len(scanInfo.Vulnerabilities.HighVulns) == 0 {
-		t.Error("expected at least one HIGH vuln to be populated")
+	total := len(scanInfo.Vulnerabilities.HighVulns) +
+		len(scanInfo.Vulnerabilities.MediumVulns) +
+		len(scanInfo.Vulnerabilities.LowVulns) +
+		len(scanInfo.Vulnerabilities.NoSecVulns)
+	if total != 0 {
+		t.Errorf("expected 0 findings for empty output, got %d", total)
 	}
 }


### PR DESCRIPTION
## Summary

`huskyci-wiz:latest-amd64` ships `wizcli` v1.45 which prints results as Unicode-bordered tables (`Libraries:`, `Secrets:`, `Data Findings:`, ...). The previous regex+state-machine parser was written against an older line-based format (`Library vulnerabilities:` ... `Name: pkg, Version: v` ... `CVE-XXXX-NNNN Severity: HIGH`) and **silently ignored every row** of the new tables. Live evidence: a production scan that printed 15 library CVEs in the `Libraries:` table caused the huskyci-client to report `no blocking vulnerabilities`.

This PR switches to JSON output, which is structured, stable, and trivially parseable.

- **`api/config.yaml`** — invoke `wizcli dir scan ... -f json > /tmp/wizResult.json 2> /tmp/errorWizScan` so stdout is a single JSON document and the wizcli ASCII banner is redirected to a separate file.
- **`api/securitytest/wizcli.go`** — replace the table parser with `parseWizCLIJSON`, a struct-based `encoding/json` decoder over `.result.libraries[]`, `.result.osPackages[]`, `.result.secrets[]`, `.result.dataFindings[]`, `.result.endOfLifeTechnologies[]`. Severity bucketing in `analyzeWizCLI` is unchanged (CRITICAL/HIGH → high, MEDIUM/MAJOR → medium, LOW/MINOR → low, everything else → info). Unparseable output is now surfaced as `ErrorFound` instead of silently returning zero findings.
- **`api/securitytest/testdata/wizcli_v1_json_sample.json`** — sanitized live JSON (12 library CVEs + 1 secret) used as a regression fixture.
- **`api/securitytest/wizcli_test.go`** — rewritten tests cover libraries, OS packages, secrets (including `INFORMATIONAL` → INFO), data findings, end-of-life, dedup, sentinel handling (`ERROR_AUTH_WIZCLI`, `ERROR_RUNNING_WIZCLI_SCAN`), invalid JSON, and a real-fixture assertion (≥12 findings parsed).

## Evidence (runtime)

Discovery + verification done in an ephemeral pod against the real `huskyci-wiz:latest-amd64` image and the live `huskyci-api-secrets`:

```
wizcli dir scan ... -f json | jq '.result | {libs:(.libraries|length), lib_vulns:([.libraries[]?.vulnerabilities[]?]|length), secrets:(.secrets|length)}'
{ "libs": 2, "lib_vulns": 12, "secrets": 1 }
```

Before the fix: `parseWizCLIStdout` returned `[]` against the table-format output. After the fix: `analyzeWizCLI` against the same JSON fixture buckets ≥12 findings across HIGH / MEDIUM / INFO.

## Test plan

- [x] `go vet ./...` (api)
- [x] `go test -race -count=1 ./...` (api + client) — all packages pass
- [x] `TestAnalyzeWizCLI_RealJSONFixture_BucketsAllSeverities` asserts the regression: real fixture → ≥12 findings, with both HIGH and MEDIUM populated.
- [ ] After merge: build/push image, bump tag in `k8s-infrastructure-live`, re-run any SAST workflow, and confirm the unified report and HuskyCI client output now show real WizCLI findings (HIGH/MEDIUM lib CVEs).
