### PR TITLE
refactor(securitytest): replace channel pattern with errgroup + scanRunner

### DIFF
--- a/api/securitytest/run.go
+++ b/api/securitytest/run.go
@@ -1,18 +1,15 @@
 package securitytest
 
 import (
-	"context" // needed for errgroup refactor (GREEN phase)
+	"context"
 	"os"
 	"strings"
-	"sync"
 
 	apiContext "github.com/githubanotaai/huskyci-api/api/context"
 	"github.com/githubanotaai/huskyci-api/api/log"
 	"github.com/githubanotaai/huskyci-api/api/types"
+	"golang.org/x/sync/errgroup"
 )
-
-// Ensure context import compiles until errgroup refactor uses it.
-var _ = context.Background
 
 // RunAllInfo store all scans results of an Analysis
 type RunAllInfo struct {
@@ -51,195 +48,110 @@ func isTestDisabled(testName string) bool {
 // Start runs both generic and language security
 func (results *RunAllInfo) Start(enryScan SecTestScanInfo) error {
 	results.Codes = enryScan.Codes
-	errChan := make(chan error)
-	waitChan := make(chan struct{})
-	syncChan := make(chan struct{})
-	var wg sync.WaitGroup
-
-	defer close(errChan)
 	defer results.setToAnalysis()
-	wg.Add(2)
 
-	go func() {
-		defer wg.Done()
-		if err := results.runGenericScans(enryScan); err != nil {
-			select {
-			case <-syncChan:
-				return
-			case errChan <- err:
-				return
-			}
-		}
-	}()
+	g, ctx := errgroup.WithContext(context.Background())
 
-	go func() {
-		defer wg.Done()
-		if err := results.runLanguageScans(enryScan); err != nil {
-			select {
-			case <-syncChan:
-				return
-			case errChan <- err:
-				return
-			}
-		}
-	}()
+	g.Go(func() error {
+		return results.runGenericScans(ctx, enryScan)
+	})
+	g.Go(func() error {
+		return results.runLanguageScans(ctx, enryScan)
+	})
 
-	go func() {
-		wg.Wait()
-		close(waitChan)
-	}()
-
-	var scanError error
-	select {
-	case <-waitChan:
-		scanError = nil
-	case err := <-errChan:
-		close(syncChan)
-		scanError = err
+	if err := g.Wait(); err != nil {
+		results.ErrorFound = err
+		return err
 	}
 
-	if scanError != nil {
-		results.ErrorFound = scanError
-		return scanError
-	}
-
-	// Set the FinalResult based on the scan results
 	results.setFinalResult()
 	return nil
 }
 
-func (results *RunAllInfo) runGenericScans(enryScan SecTestScanInfo) error {
+func (results *RunAllInfo) runGenericScans(ctx context.Context, enryScan SecTestScanInfo) error {
+	g, ctx := errgroup.WithContext(ctx)
+	runner := results.getRunner()
 
-	errChan := make(chan error)
-	waitChan := make(chan struct{})
-	syncChan := make(chan struct{})
-
-	var wg sync.WaitGroup
-
-	defer close(errChan)
-
-	genericTests, err := getAllDefaultSecurityTests("Generic", "")
+	genericTests, err := runner.listGenericTests()
 	if err != nil {
 		return err
 	}
 
-	for genericTestIndex := range genericTests {
-		// Skip disabled security tests
-		if isTestDisabled(genericTests[genericTestIndex].Name) {
-			log.Info("runGenericScans", "SECURITYTEST", 0, "Skipping disabled test: "+genericTests[genericTestIndex].Name)
+	for i := range genericTests {
+		testName := genericTests[i].Name
+		if isTestDisabled(testName) {
+			log.Info("runGenericScans", "SECURITYTEST", 0, "Skipping disabled test: "+testName)
 			continue
 		}
-		wg.Add(1)
-		go func(genericTest *types.SecurityTest) {
-			defer wg.Done()
-			newGenericScan := SecTestScanInfo{}
-			// LanguageExclusions is only utilized on first scan (enryScan) therefore set as nil
-			enryScan.LanguageExclusions = nil
-			if err := newGenericScan.New(enryScan.RID, enryScan.URL, enryScan.Branch, genericTest.Name, enryScan.LanguageExclusions, enryScan.DockerHost); err != nil {
-				select {
-				case <-syncChan:
-					return
-				case errChan <- err:
-					return
-				}
+		g.Go(func() error {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
 			}
-			if err := newGenericScan.Start(); err != nil {
-				select {
-				case <-syncChan:
-					return
-				case errChan <- err:
-					return
-				}
+
+			scan, err := runner.newScan(enryScan.RID, enryScan.URL, enryScan.Branch, testName, nil, enryScan.DockerHost)
+			if err != nil {
+				return err
 			}
-			results.Containers = append(results.Containers, newGenericScan.Container)
-			switch genericTest.Name {
+			if err := runner.startScan(scan); err != nil {
+				return err
+			}
+			results.Containers = append(results.Containers, scan.Container)
+			switch testName {
 			case "gitauthors":
-				results.CommitAuthors = newGenericScan.CommitAuthors.Authors
+				results.CommitAuthors = scan.CommitAuthors.Authors
 			case "gitleaks", "wizcli":
-				results.setVulns(newGenericScan)
+				results.setVulns(*scan)
 			}
-		}(&genericTests[genericTestIndex])
+			return nil
+		})
 	}
 
-	go func() {
-		wg.Wait()
-		close(waitChan)
-	}()
-
-	select {
-	case <-waitChan:
-		return nil
-	case err := <-errChan:
-		close(syncChan)
-		return err
-	}
+	return g.Wait()
 }
 
-func (results *RunAllInfo) runLanguageScans(enryScan SecTestScanInfo) error {
-
-	errChan := make(chan error)
-	waitChan := make(chan struct{})
-	syncChan := make(chan struct{})
-
-	var wg sync.WaitGroup
-
-	defer close(errChan)
+func (results *RunAllInfo) runLanguageScans(ctx context.Context, enryScan SecTestScanInfo) error {
+	g, ctx := errgroup.WithContext(ctx)
+	runner := results.getRunner()
 
 	languageTests := []types.SecurityTest{}
 	for _, code := range enryScan.Codes {
-		codeTests, err := getAllDefaultSecurityTests("Language", code.Language)
+		codeTests, err := runner.listLanguageTests(code.Language)
 		if err != nil {
 			return err
 		}
 		languageTests = append(languageTests, codeTests...)
 	}
 
-	for languageTestIndex := range languageTests {
-		// Skip disabled security tests
-		if isTestDisabled(languageTests[languageTestIndex].Name) {
-			log.Info("runLanguageScans", "SECURITYTEST", 0, "Skipping disabled test: "+languageTests[languageTestIndex].Name)
+	for i := range languageTests {
+		testName := languageTests[i].Name
+		if isTestDisabled(testName) {
+			log.Info("runLanguageScans", "SECURITYTEST", 0, "Skipping disabled test: "+testName)
 			continue
 		}
-		wg.Add(1)
-		go func(languageTest *types.SecurityTest) {
-			defer wg.Done()
-			newLanguageScan := SecTestScanInfo{}
-			// LanguageExclusions is only utilized on first scan (enryScan) therefore set as nil
-			enryScan.LanguageExclusions = nil
-			if err := newLanguageScan.New(enryScan.RID, enryScan.URL, enryScan.Branch, languageTest.Name, enryScan.LanguageExclusions, enryScan.DockerHost); err != nil {
-				select {
-				case <-syncChan:
-					return
-				case errChan <- err:
-					return
-				}
+		g.Go(func() error {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
 			}
-			if err := newLanguageScan.Start(); err != nil {
-				results.Containers = append(results.Containers, newLanguageScan.Container)
-				select {
-				case <-syncChan:
-					return
-				case errChan <- err:
-					return
-				}
+
+			scan, err := runner.newScan(enryScan.RID, enryScan.URL, enryScan.Branch, testName, nil, enryScan.DockerHost)
+			if err != nil {
+				return err
 			}
-			results.Containers = append(results.Containers, newLanguageScan.Container)
-			results.setVulns(newLanguageScan)
-		}(&languageTests[languageTestIndex])
+			if err := runner.startScan(scan); err != nil {
+				results.Containers = append(results.Containers, scan.Container)
+				return err
+			}
+			results.Containers = append(results.Containers, scan.Container)
+			results.setVulns(*scan)
+			return nil
+		})
 	}
 
-	go func() {
-		wg.Wait()
-		close(waitChan)
-	}()
-
-	select {
-	case <-waitChan:
-		return nil
-	case err := <-errChan:
-		close(syncChan)
-		return err
-	}
+	return g.Wait()
 }
 
 func (results *RunAllInfo) setVulns(securityTestScan SecTestScanInfo) {

--- a/api/securitytest/run.go
+++ b/api/securitytest/run.go
@@ -1,6 +1,7 @@
 package securitytest
 
 import (
+	"context" // needed for errgroup refactor (GREEN phase)
 	"os"
 	"strings"
 	"sync"
@@ -10,8 +11,12 @@ import (
 	"github.com/githubanotaai/huskyci-api/api/types"
 )
 
+// Ensure context import compiles until errgroup refactor uses it.
+var _ = context.Background
+
 // RunAllInfo store all scans results of an Analysis
 type RunAllInfo struct {
+	runner         scanRunner        `json:"-" bson:"-"`
 	RID            string
 	Status         string
 	Containers     []types.Container
@@ -419,4 +424,11 @@ func (results *RunAllInfo) setFinalResult() {
 	} else {
 		results.FinalResult = "failed"
 	}
+}
+
+func (results *RunAllInfo) getRunner() scanRunner {
+	if results.runner != nil {
+		return results.runner
+	}
+	return realRunner{}
 }

--- a/api/securitytest/run_test.go
+++ b/api/securitytest/run_test.go
@@ -5,8 +5,11 @@
 package securitytest
 
 import (
+	"fmt"
 	"os"
 	"testing"
+
+	"github.com/githubanotaai/huskyci-api/api/types"
 )
 
 func TestIsTestDisabled(t *testing.T) {
@@ -95,4 +98,98 @@ func upper(s string) string {
 		}
 	}
 	return string(result)
+}
+
+func TestStart_FirstErrorCancelsRemaining(t *testing.T) {
+	mockGenericTests := []types.SecurityTest{
+		{Name: "gitleaks"},
+		{Name: "gitauthors"},
+	}
+
+	runner := &mockRunner{
+		genericTests: mockGenericTests,
+		newScanFunc: func(RID, URL, branch, name string, le map[string]bool, dh string) (*SecTestScanInfo, error) {
+			return &SecTestScanInfo{
+				RID:              RID,
+				SecurityTestName: name,
+				Container:        types.Container{CID: "cid-" + name, CResult: "passed"},
+			}, nil
+		},
+		startScanFunc: func(scan *SecTestScanInfo) error {
+			if scan.SecurityTestName == "gitleaks" {
+				return fmt.Errorf("gitleaks scan failed")
+			}
+			return nil
+		},
+	}
+
+	results := &RunAllInfo{runner: runner}
+	enryScan := SecTestScanInfo{
+		RID: "test-rid", URL: "https://example.com/repo", Branch: "main",
+	}
+
+	err := results.Start(enryScan)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if err.Error() != "gitleaks scan failed" {
+		t.Errorf("expected 'gitleaks scan failed', got %q", err.Error())
+	}
+}
+
+func TestStart_ConcurrentErrorsNoPanic(t *testing.T) {
+	mockGenericTests := []types.SecurityTest{
+		{Name: "gitleaks"}, {Name: "gitauthors"},
+	}
+
+	runner := &mockRunner{
+		genericTests: mockGenericTests,
+		newScanFunc: func(RID, URL, branch, name string, le map[string]bool, dh string) (*SecTestScanInfo, error) {
+			return &SecTestScanInfo{
+				RID: RID, SecurityTestName: name,
+				Container: types.Container{CID: "cid-" + name},
+			}, nil
+		},
+		startScanFunc: func(scan *SecTestScanInfo) error {
+			return fmt.Errorf("scan %s failed", scan.SecurityTestName)
+		},
+	}
+
+	results := &RunAllInfo{runner: runner}
+	enryScan := SecTestScanInfo{
+		RID: "test-rid-stress", URL: "https://example.com/repo", Branch: "main",
+	}
+
+	err := results.Start(enryScan)
+	if err == nil {
+		t.Fatal("expected error with all scans failing")
+	}
+	// Key: no panic occurred
+}
+
+func TestStart_AllScansPass(t *testing.T) {
+	mockGenericTests := []types.SecurityTest{
+		{Name: "gitleaks"}, {Name: "gitauthors"},
+	}
+
+	runner := &mockRunner{
+		genericTests: mockGenericTests,
+		newScanFunc: func(RID, URL, branch, name string, le map[string]bool, dh string) (*SecTestScanInfo, error) {
+			return &SecTestScanInfo{
+				RID: RID, SecurityTestName: name,
+				Container: types.Container{CID: "cid-" + name, CResult: "passed", CStatus: "finished"},
+			}, nil
+		},
+		startScanFunc: func(scan *SecTestScanInfo) error { return nil },
+	}
+
+	results := &RunAllInfo{runner: runner}
+	enryScan := SecTestScanInfo{
+		RID: "test-rid-pass", URL: "https://example.com/repo", Branch: "main",
+	}
+
+	err := results.Start(enryScan)
+	if err != nil {
+		t.Errorf("expected nil, got %v", err)
+	}
 }

--- a/api/securitytest/runner.go
+++ b/api/securitytest/runner.go
@@ -1,0 +1,62 @@
+package securitytest
+
+import "github.com/githubanotaai/huskyci-api/api/types"
+
+// scanRunner abstracts scan lifecycle so tests can mock
+// DB queries and scan execution without MongoDB or K8s.
+type scanRunner interface {
+	listGenericTests() ([]types.SecurityTest, error)
+	listLanguageTests(language string) ([]types.SecurityTest, error)
+	newScan(RID, URL, branch, securityTestName string, languageExclusions map[string]bool, dockerHost string) (*SecTestScanInfo, error)
+	startScan(scan *SecTestScanInfo) error
+}
+
+// realRunner delegates to actual SecTestScanInfo + DB methods.
+type realRunner struct{}
+
+func (realRunner) listGenericTests() ([]types.SecurityTest, error) {
+	return getAllDefaultSecurityTests("Generic", "")
+}
+
+func (realRunner) listLanguageTests(language string) ([]types.SecurityTest, error) {
+	return getAllDefaultSecurityTests("Language", language)
+}
+
+func (realRunner) newScan(RID, URL, branch, securityTestName string, languageExclusions map[string]bool, dockerHost string) (*SecTestScanInfo, error) {
+	scan := &SecTestScanInfo{}
+	return scan, scan.New(RID, URL, branch, securityTestName, languageExclusions, dockerHost)
+}
+
+func (realRunner) startScan(scan *SecTestScanInfo) error {
+	return scan.Start()
+}
+
+// mockRunner returns preconfigured results for testing.
+type mockRunner struct {
+	genericTests  []types.SecurityTest
+	languageTests []types.SecurityTest
+	newScanFunc   func(RID, URL, branch, securityTestName string, languageExclusions map[string]bool, dockerHost string) (*SecTestScanInfo, error)
+	startScanFunc func(scan *SecTestScanInfo) error
+}
+
+func (m *mockRunner) listGenericTests() ([]types.SecurityTest, error) {
+	return m.genericTests, nil
+}
+
+func (m *mockRunner) listLanguageTests(language string) ([]types.SecurityTest, error) {
+	return m.languageTests, nil
+}
+
+func (m *mockRunner) newScan(RID, URL, branch, securityTestName string, languageExclusions map[string]bool, dockerHost string) (*SecTestScanInfo, error) {
+	if m.newScanFunc != nil {
+		return m.newScanFunc(RID, URL, branch, securityTestName, languageExclusions, dockerHost)
+	}
+	return &SecTestScanInfo{}, nil
+}
+
+func (m *mockRunner) startScan(scan *SecTestScanInfo) error {
+	if m.startScanFunc != nil {
+		return m.startScanFunc(scan)
+	}
+	return nil
+}


### PR DESCRIPTION
## Problem

`Start()`, `runGenericScans()`, and `runLanguageScans()` orchestrate goroutines using manual channel patterns (`errChan`, `syncChan`, `waitChan`) with `sync.WaitGroup`. This causes a **`panic: send on closed channel`** when a goroutine tries to send on `errChan` after `syncChan` is closed by a prior error — a classic close-ordering race.

**Root cause timeline:**
1. Scan A fails → sends error to `errChan`
2. Goroutine reading `errChan` receives error → closes `syncChan`
3. Scan B (still running) finishes → tries to send on `errChan` (via `select { case <-syncChan: return; case errChan <- err: return }`)
4. But `errChan` was already drained and `defer close(errChan)` has not run yet OR the goroutine reads from `errChan` after close — either way, undefined behavior

The same triplet pattern (3 channels + WaitGroup) is duplicated across all 3 functions.

## Solution

Replace the manual channel/WaitGroup pattern with `golang.org/x/sync/errgroup.WithContext`:

- **`Start()`**: Two `g.Go()` calls (generic + language), `g.Wait()` returns first error
- **`runGenericScans()` / `runLanguageScans()`**: Nested errgroup with per-scan `g.Go()`; `ctx.Done()` check before each scan provides early cancellation
- **`scanRunner` interface**: Abstracts `getAllDefaultSecurityTests`, `SecTestScanInfo.New`, and `SecTestScanInfo.Start` so tests can mock DB + K8s calls
- **`realRunner`**: Delegates to actual implementation (zero behavior change for production)
- **`mockRunner`**: Preconfigured for unit tests

## Changes

| File | Change |
|------|--------|
| `api/securitytest/run.go` | Replace 3 channel patterns with errgroup; add `runner` field + `getRunner()`; rm `sync` import, add `context` + `errgroup` |
| `api/securitytest/runner.go` | New file: `scanRunner` interface + `realRunner` + `mockRunner` |
| `api/securitytest/run_test.go` | 3 new tests: `TestStart_FirstErrorCancelsRemaining`, `TestStart_ConcurrentErrorsNoPanic`, `TestStart_AllScansPass` |

**Net**: -149 lines of channel orchestration, +83 lines of errgroup + interface code.

## Bug fix included

The old code mutated `enryScan.LanguageExclusions` inside goroutines (setting it to `nil` after the first scan). This was flagged with a comment "LanguageExclusions is only utilized on first scan (enryScan) therefore set as nil" but the mutation happened inside a goroutine, creating a data race on the `enryScan` struct. The refactored code passes `nil` directly to `runner.newScan()`, eliminating this mutation.

## Testing

All tests pass:

```
=== RUN   TestStart_FirstErrorCancelsRemaining    --- PASS
=== RUN   TestStart_ConcurrentErrorsNoPanic        --- PASS
=== RUN   TestStart_AllScansPass                   --- PASS
=== RUN   TestIsTestDisabled                       --- PASS (7 sub-tests)
```

`go vet` clean. Note: a data race on `results.Containers`/`CommitAuthors`/`setVulns` still exists and is addressed in PR #<TODO> (mutex fix).

## Dependency

- `golang.org/x/sync v0.8.0` was already in `go.mod` (indirect); now imported directly

## Out of scope

- **Mutex protection** for shared state mutations (`Containers`, `CommitAuthors`, `setVulns`) — tracked separately
- **Refactoring `SecTestScanInfo.Start()`** to be mockable via interface (currently `realRunner.startScan` calls it directly; future work could add a `scanStarter` interface)