### PR TITLE
fix(securitytest): add sync.Mutex to protect shared state in errgroup goroutines

### DIFF
--- a/api/securitytest/run.go
+++ b/api/securitytest/run.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"strings"
+	"sync"
 
 	apiContext "github.com/githubanotaai/huskyci-api/api/context"
 	"github.com/githubanotaai/huskyci-api/api/log"
@@ -14,6 +15,7 @@ import (
 // RunAllInfo store all scans results of an Analysis
 type RunAllInfo struct {
 	runner         scanRunner        `json:"-" bson:"-"`
+	mu             sync.Mutex        `json:"-" bson:"-"`
 	RID            string
 	Status         string
 	Containers     []types.Container
@@ -97,6 +99,7 @@ func (results *RunAllInfo) runGenericScans(ctx context.Context, enryScan SecTest
 			if err := runner.startScan(scan); err != nil {
 				return err
 			}
+			results.mu.Lock()
 			results.Containers = append(results.Containers, scan.Container)
 			switch testName {
 			case "gitauthors":
@@ -104,6 +107,7 @@ func (results *RunAllInfo) runGenericScans(ctx context.Context, enryScan SecTest
 			case "gitleaks", "wizcli":
 				results.setVulns(*scan)
 			}
+			results.mu.Unlock()
 			return nil
 		})
 	}
@@ -142,11 +146,15 @@ func (results *RunAllInfo) runLanguageScans(ctx context.Context, enryScan SecTes
 				return err
 			}
 			if err := runner.startScan(scan); err != nil {
+				results.mu.Lock()
 				results.Containers = append(results.Containers, scan.Container)
+				results.mu.Unlock()
 				return err
 			}
+			results.mu.Lock()
 			results.Containers = append(results.Containers, scan.Container)
 			results.setVulns(*scan)
+			results.mu.Unlock()
 			return nil
 		})
 	}

--- a/api/securitytest/run_test.go
+++ b/api/securitytest/run_test.go
@@ -193,3 +193,52 @@ func TestStart_AllScansPass(t *testing.T) {
 		t.Errorf("expected nil, got %v", err)
 	}
 }
+
+func TestStart_ConcurrentWritesDataRace(t *testing.T) {
+	mockGenericTests := []types.SecurityTest{
+		{Name: "gitleaks"},
+		{Name: "gitauthors"},
+	}
+
+	runner := &mockRunner{
+		genericTests: mockGenericTests,
+		newScanFunc: func(RID, URL, branch, name string, le map[string]bool, dh string) (*SecTestScanInfo, error) {
+			scan := &SecTestScanInfo{
+				RID:              RID,
+				SecurityTestName: name,
+				Container: types.Container{
+					CID:     "cid-" + name,
+					CResult: "passed",
+					CStatus: "finished",
+				},
+				CommitAuthors: GitAuthorsOutput{
+					Authors: []string{"author-" + name},
+				},
+			}
+			// Add vulns for gitleaks so setVulns has data to append
+			if name == "gitleaks" {
+				scan.Vulnerabilities = types.HuskyCISecurityTestOutput{
+					HighVulns: []types.HuskyCIVulnerability{{Details: name + "-high-vuln"}},
+				}
+			}
+			return scan, nil
+		},
+		startScanFunc: func(scan *SecTestScanInfo) error { return nil },
+	}
+
+	results := &RunAllInfo{runner: runner}
+	enryScan := SecTestScanInfo{
+		RID: "race-test-rid", URL: "https://example.com/repo", Branch: "main",
+	}
+
+	// This triggers concurrent Container append + CommitAuthors + setVulns writes
+	err := results.Start(enryScan)
+	if err != nil {
+		t.Errorf("expected nil, got %v", err)
+	}
+
+	// Verify we got results from both scans (basic correctness)
+	if len(results.Containers) < 2 {
+		t.Errorf("expected at least 2 containers, got %d", len(results.Containers))
+	}
+}


### PR DESCRIPTION
## Problem

After the errgroup refactor (PR #15), goroutines in `runGenericScans()` and `runLanguageScans()` concurrently mutate shared `RunAllInfo` state without synchronization:

- `results.Containers = append(results.Containers, scan.Container)` — **concurrent slice append**
- `results.CommitAuthors = scan.CommitAuthors.Authors` — **concurrent assignment**
- `results.setVulns(*scan)` — **concurrent append to `HuskyCIResults` slices**

Detected by `go test -race`:

```
WARNING: DATA RACE
Write at 0x00c0000ea090 by goroutine 37:
  .../run.go:100 +0x1e4  // append(results.Containers, ...)

Previous write at 0x00c0000ea090 by goroutine 38:
  .../run.go:100 +0x1e4
```

## Solution

Add `mu sync.Mutex` (with `json:"-" bson:"-"` tags) to `RunAllInfo` and wrap all shared-state mutations inside `g.Go()` callbacks with `Lock()/Unlock()`.

**Scope is deliberately narrow**: only the 3-4 lines that mutate shared state are locked. Scan execution (`runner.startScan()`) runs unlocked, preserving full parallelism.

## Changes

| File | Change |
|------|--------|
| `api/securitytest/run.go` | Add `mu sync.Mutex` field; 3 Lock/Unlock pairs protecting Container append, CommitAuthors, and setVulns |
| `api/securitytest/run_test.go` | New test: `TestStart_ConcurrentWritesDataRace` (exercises all 3 mutation sites) |

**Net**: +57 lines (8 in run.go, 49 in run_test.go).

## Mutex placement

```
runGenericScans():
  runner.startScan(scan)      // UNLOCKED — parallel scan execution
  ┌ results.mu.Lock()
  │ results.Containers = append(...)
  │ switch testName {
  │ case "gitauthors": results.CommitAuthors = ...
  │ case "gitleaks", "wizcli": results.setVulns(...)
  │ }
  └ results.mu.Unlock()

runLanguageScans():
  // error path:
  runner.startScan(scan)      // UNLOCKED
  ┌ results.mu.Lock()
  └ results.Containers = append(...)
  └ results.mu.Unlock()
  return err

  // success path:
  runner.startScan(scan)      // UNLOCKED
  ┌ results.mu.Lock()
  │ results.Containers = append(...)
  │ results.setVulns(*scan)
  └ results.mu.Unlock()
```

## Testing

All 38 tests pass with `-race`:

```
go test -race ./securitytest/ — PASS (0 data races)
```

The `TestStart_ConcurrentWritesDataRace` test specifically exercises concurrent Container append + CommitAuthors + setVulns writes.

## Dependency

- **Requires PR #15** (errgroup refactor) — this branch is based on `fix/errgroup-channel-race`

## Out of scope

- Using a channel-based result collector instead of mutex (considered; adds complexity for no measurable performance gain given the ~5-10 goroutines involved)
- Using `sync.RWMutex` (not applicable — all accesses are writes, no read-only paths)