### PR TITLE
feat: Split monolithic wizcli into 3 security tests

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -418,10 +418,10 @@ securitycodescan:
   default: true
   timeOutInSeconds: 360
 
-wizcli:
-  name: wizcli
+wizcli_secrets:
+  name: wizcli_secrets
   image: 939030204144.dkr.ecr.us-east-1.amazonaws.com/huskyci-wiz
-  imageTag: "latest-amd64"
+  imageTag: "f793155-amd64"
   cmd: |+
     mkdir -p ~/.ssh &&
     echo '%GIT_PRIVATE_SSH_KEY%' > ~/.ssh/huskyci_id_rsa &&
@@ -435,9 +435,10 @@ wizcli:
             echo 'ERROR_AUTH_WIZCLI'
             cat /tmp/errorWizAuth
         else
-            wizcli dir scan --path ./code --sensitive-data --secrets \
-              --file-hashes-scan --policy "aai-secrets-default-policy" \
-              -f json > /tmp/wizResult.json 2> /tmp/errorWizScan
+            wizcli scan dir ./code \
+              --disabled-scanners Vulnerability,Misconfiguration,SAST,Malware,AIModels,SoftwareSupplyChain \
+              --by-policy-hits=DISABLED \
+              --stdout=json --json-output-file=/tmp/wizResult.json 2> /tmp/errorWizScan
             SCAN_RC=$?
             if [ $SCAN_RC -ge 2 ]; then
               echo "ERROR_RUNNING_WIZCLI_SCAN"
@@ -452,4 +453,78 @@ wizcli:
     fi
   type: Generic
   default: true
-  timeOutInSeconds: 600
+  timeOutInSeconds: 120
+
+wizcli_iac_sast:
+  name: wizcli_iac_sast
+  image: 939030204144.dkr.ecr.us-east-1.amazonaws.com/huskyci-wiz
+  imageTag: "f793155-amd64"
+  cmd: |+
+    mkdir -p ~/.ssh &&
+    echo '%GIT_PRIVATE_SSH_KEY%' > ~/.ssh/huskyci_id_rsa &&
+    chmod 600 ~/.ssh/huskyci_id_rsa &&
+    echo "IdentityFile ~/.ssh/huskyci_id_rsa" >> /etc/ssh/ssh_config &&
+    echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
+    GIT_TERMINAL_PROMPT=0 git clone -b %GIT_BRANCH% --single-branch --depth 1 %GIT_REPO% code --quiet 2>/tmp/errorGitCloneWiz
+    if [ $? -eq 0 ]; then
+        wizcli auth --id '%WIZ_CLIENT_ID%' --secret '%WIZ_CLIENT_SECRET%' > /tmp/errorWizAuth 2>&1
+        if [ $? -ne 0 ]; then
+            echo 'ERROR_AUTH_WIZCLI'
+            cat /tmp/errorWizAuth
+        else
+            wizcli scan dir ./code \
+              --disabled-scanners Vulnerability,Secret,SensitiveData,Malware,AIModels,SoftwareSupplyChain \
+              --by-policy-hits=DISABLED \
+              --stdout=json --json-output-file=/tmp/wizResult.json 2> /tmp/errorWizScan
+            SCAN_RC=$?
+            if [ $SCAN_RC -ge 2 ]; then
+              echo "ERROR_RUNNING_WIZCLI_SCAN"
+              cat /tmp/errorWizScan
+            else
+              cat /tmp/wizResult.json
+            fi
+        fi
+    else
+        echo "ERROR_CLONING"
+        cat /tmp/errorGitCloneWiz
+    fi
+  type: Generic
+  default: true
+  timeOutInSeconds: 300
+
+wizcli_vulns:
+  name: wizcli_vulns
+  image: 939030204144.dkr.ecr.us-east-1.amazonaws.com/huskyci-wiz
+  imageTag: "f793155-amd64"
+  cmd: |+
+    mkdir -p ~/.ssh &&
+    echo '%GIT_PRIVATE_SSH_KEY%' > ~/.ssh/huskyci_id_rsa &&
+    chmod 600 ~/.ssh/huskyci_id_rsa &&
+    echo "IdentityFile ~/.ssh/huskyci_id_rsa" >> /etc/ssh/ssh_config &&
+    echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
+    GIT_TERMINAL_PROMPT=0 git clone -b %GIT_BRANCH% --single-branch --depth 1 %GIT_REPO% code --quiet 2>/tmp/errorGitCloneWiz
+    if [ $? -eq 0 ]; then
+        wizcli auth --id '%WIZ_CLIENT_ID%' --secret '%WIZ_CLIENT_SECRET%' > /tmp/errorWizAuth 2>&1
+        if [ $? -ne 0 ]; then
+            echo 'ERROR_AUTH_WIZCLI'
+            cat /tmp/errorWizAuth
+        else
+            wizcli scan dir ./code \
+              --disabled-scanners Secret,SensitiveData,Misconfiguration,SAST,AIModels,SoftwareSupplyChain \
+              --by-policy-hits=DISABLED \
+              --stdout=json --json-output-file=/tmp/wizResult.json 2> /tmp/errorWizScan
+            SCAN_RC=$?
+            if [ $SCAN_RC -ge 2 ]; then
+              echo "ERROR_RUNNING_WIZCLI_SCAN"
+              cat /tmp/errorWizScan
+            else
+              cat /tmp/wizResult.json
+            fi
+        fi
+    else
+        echo "ERROR_CLONING"
+        cat /tmp/errorGitCloneWiz
+    fi
+  type: Generic
+  default: true
+  timeOutInSeconds: 300

--- a/api/config.yaml
+++ b/api/config.yaml
@@ -510,7 +510,7 @@ wizcli_vulns:
             cat /tmp/errorWizAuth
         else
             wizcli scan dir ./code \
-              --disabled-scanners Secret,SensitiveData,Misconfiguration,SAST,AIModels,SoftwareSupplyChain \
+              --disabled-scanners Secret,SensitiveData,Misconfiguration,SAST \
               --by-policy-hits=DISABLED \
               --stdout=json --json-output-file=/tmp/wizResult.json 2> /tmp/errorWizScan
             SCAN_RC=$?

--- a/api/context/context.go
+++ b/api/context/context.go
@@ -104,7 +104,9 @@ type APIConfig struct {
 	SafetySecurityTest           *types.SecurityTest
 	TFSecSecurityTest            *types.SecurityTest
 	SecurityCodeScanSecurityTest *types.SecurityTest
-	WizcliSecurityTest           *types.SecurityTest
+	WizcliSecretsSecurityTest    *types.SecurityTest
+	WizcliIacSastSecurityTest    *types.SecurityTest
+	WizcliVulnsSecurityTest      *types.SecurityTest
 	DBInstance                   db.Requests
 	Cache                        *cache.Cache
 }
@@ -158,7 +160,9 @@ func (dF DefaultConfig) SetOnceConfig() {
 			SafetySecurityTest:           dF.getSecurityTestConfig("safety"),
 			TFSecSecurityTest:            dF.getSecurityTestConfig("tfsec"),
 			SecurityCodeScanSecurityTest: dF.getSecurityTestConfig("securitycodescan"),
-			WizcliSecurityTest:           dF.getSecurityTestConfig("wizcli"),
+			WizcliSecretsSecurityTest:    dF.getSecurityTestConfig("wizcli_secrets"),
+			WizcliIacSastSecurityTest:    dF.getSecurityTestConfig("wizcli_iac_sast"),
+			WizcliVulnsSecurityTest:      dF.getSecurityTestConfig("wizcli_vulns"),
 			DBInstance:                   dF.GetDB(),
 			Cache:                        dF.GetCache(),
 		}

--- a/api/context/context_test.go
+++ b/api/context/context_test.go
@@ -462,7 +462,27 @@ var _ = Describe("Context", func() {
 						Default:          fakeCaller.expectedBoolFromConfig,
 						TimeOutInSeconds: fakeCaller.expectedIntFromConfig,
 					},
-					WizcliSecurityTest: &types.SecurityTest{
+					WizcliSecretsSecurityTest: &types.SecurityTest{
+					Name:             fakeCaller.expectedStringFromConfig,
+					Image:            fakeCaller.expectedStringFromConfig,
+					ImageTag:         fakeCaller.expectedStringFromConfig,
+					Cmd:              fakeCaller.expectedStringFromConfig,
+					Type:             fakeCaller.expectedStringFromConfig,
+					Language:         fakeCaller.expectedStringFromConfig,
+					Default:          fakeCaller.expectedBoolFromConfig,
+					TimeOutInSeconds: fakeCaller.expectedIntFromConfig,
+				},
+				WizcliIacSastSecurityTest: &types.SecurityTest{
+					Name:             fakeCaller.expectedStringFromConfig,
+					Image:            fakeCaller.expectedStringFromConfig,
+					ImageTag:         fakeCaller.expectedStringFromConfig,
+					Cmd:              fakeCaller.expectedStringFromConfig,
+					Type:             fakeCaller.expectedStringFromConfig,
+					Language:         fakeCaller.expectedStringFromConfig,
+					Default:          fakeCaller.expectedBoolFromConfig,
+					TimeOutInSeconds: fakeCaller.expectedIntFromConfig,
+				},
+				WizcliVulnsSecurityTest: &types.SecurityTest{
 						Name:             fakeCaller.expectedStringFromConfig,
 						Image:            fakeCaller.expectedStringFromConfig,
 						ImageTag:         fakeCaller.expectedStringFromConfig,
@@ -481,18 +501,18 @@ var _ = Describe("Context", func() {
 		})
 	})
 	Describe("SetOnceConfig", func() {
-		Context("When SetOnceConfig is called with a FakeCaller returning 'wizcli' for string config", func() {
-			It("Should set WizcliSecurityTest with the expected name", func() {
+		Context("When SetOnceConfig is called with a FakeCaller returning 'wizcli_secrets' for string config", func() {
+			It("Should set WizcliSecretsSecurityTest with the expected name", func() {
 				fakeCaller := FakeCaller{
-					expectedStringFromConfig: "wizcli",
+					expectedStringFromConfig: "wizcli_secrets",
 				}
 				config := DefaultConfig{
 					Caller: &fakeCaller,
 				}
 				ResetOnceConfig()
 				config.SetOnceConfig()
-				Expect(APIConfiguration.WizcliSecurityTest).NotTo(BeNil())
-				Expect(APIConfiguration.WizcliSecurityTest.Name).To(Equal("wizcli"))
+				Expect(APIConfiguration.WizcliSecretsSecurityTest).NotTo(BeNil())
+				Expect(APIConfiguration.WizcliSecretsSecurityTest.Name).To(Equal("wizcli_secrets"))
 			})
 		})
 	})

--- a/api/kubernetes/huskykube.go
+++ b/api/kubernetes/huskykube.go
@@ -43,7 +43,9 @@ func KubeRun(image, imageTag, cmd, securityTestName, id string, podSchedulingTim
 	log.Info(logActionRun, logInfoHuskyKube, 41, k.PID)
 
 	_, fullContainerImage := configureImagePath(image, imageTag)
-	podName := fmt.Sprintf("%s-%s", strings.ToLower(id), securityTestName)
+	// Sanitize test name for DNS label compliance (RFC 1123): replace underscores with hyphens
+	sanitizedTestName := strings.ReplaceAll(securityTestName, "_", "-")
+	podName := fmt.Sprintf("%s-%s", strings.ToLower(id), sanitizedTestName)
 
 	// step 3: create a new container given an image and it's cmd
 	podUID, err := k.CreatePod(fullContainerImage, cmd, podName, securityTestName)

--- a/api/securitytest/run.go
+++ b/api/securitytest/run.go
@@ -36,7 +36,11 @@ const spotbugs = "spotbugs"
 const gitleaks = "gitleaks"
 const tfsec = "tfsec"
 const securitycodescan = "securitycodescan"
-const wizcli = "wizcli"
+const (
+	wizcliSecrets = "wizcli_secrets"
+	wizcliIacSast  = "wizcli_iac_sast"
+	wizcliVulns    = "wizcli_vulns"
+)
 
 // isTestDisabled checks if a security test is disabled via environment variable.
 // The env var pattern is: HUSKYCI_DISABLE_<TESTNAME> (e.g., HUSKYCI_DISABLE_GITAUTHORS=true)
@@ -104,7 +108,7 @@ func (results *RunAllInfo) runGenericScans(ctx context.Context, enryScan SecTest
 			switch testName {
 			case "gitauthors":
 				results.CommitAuthors = scan.CommitAuthors.Authors
-			case "gitleaks", "wizcli":
+			case "gitleaks", "wizcli_secrets", "wizcli_iac_sast", "wizcli_vulns":
 				results.setVulns(*scan)
 			}
 			results.mu.Unlock()
@@ -182,8 +186,12 @@ func (results *RunAllInfo) setVulns(securityTestScan SecTestScanInfo) {
 			results.HuskyCIResults.JavaResults.HuskyCISpotBugsOutput.HighVulns = append(results.HuskyCIResults.JavaResults.HuskyCISpotBugsOutput.HighVulns, highVuln)
 		case gitleaks:
 			results.HuskyCIResults.GenericResults.HuskyCIGitleaksOutput.HighVulns = append(results.HuskyCIResults.GenericResults.HuskyCIGitleaksOutput.HighVulns, highVuln)
-		case wizcli:
-			results.HuskyCIResults.GenericResults.HuskyCIWizCLIOutput.HighVulns = append(results.HuskyCIResults.GenericResults.HuskyCIWizCLIOutput.HighVulns, highVuln)
+		case wizcliSecrets:
+			results.HuskyCIResults.GenericResults.HuskyCIWizCLISecretsOutput.HighVulns = append(results.HuskyCIResults.GenericResults.HuskyCIWizCLISecretsOutput.HighVulns, highVuln)
+		case wizcliIacSast:
+			results.HuskyCIResults.GenericResults.HuskyCIIacSastOutput.HighVulns = append(results.HuskyCIResults.GenericResults.HuskyCIIacSastOutput.HighVulns, highVuln)
+		case wizcliVulns:
+			results.HuskyCIResults.GenericResults.HuskyCIWizCLIVulnsOutput.HighVulns = append(results.HuskyCIResults.GenericResults.HuskyCIWizCLIVulnsOutput.HighVulns, highVuln)
 		case tfsec:
 			results.HuskyCIResults.HclResults.HuskyCITFSecOutput.HighVulns = append(results.HuskyCIResults.HclResults.HuskyCITFSecOutput.HighVulns, highVuln)
 		case securitycodescan:
@@ -209,8 +217,12 @@ func (results *RunAllInfo) setVulns(securityTestScan SecTestScanInfo) {
 			results.HuskyCIResults.JavaResults.HuskyCISpotBugsOutput.MediumVulns = append(results.HuskyCIResults.JavaResults.HuskyCISpotBugsOutput.MediumVulns, mediumVuln)
 		case gitleaks:
 			results.HuskyCIResults.GenericResults.HuskyCIGitleaksOutput.MediumVulns = append(results.HuskyCIResults.GenericResults.HuskyCIGitleaksOutput.MediumVulns, mediumVuln)
-		case wizcli:
-			results.HuskyCIResults.GenericResults.HuskyCIWizCLIOutput.MediumVulns = append(results.HuskyCIResults.GenericResults.HuskyCIWizCLIOutput.MediumVulns, mediumVuln)
+		case wizcliSecrets:
+			results.HuskyCIResults.GenericResults.HuskyCIWizCLISecretsOutput.MediumVulns = append(results.HuskyCIResults.GenericResults.HuskyCIWizCLISecretsOutput.MediumVulns, mediumVuln)
+		case wizcliIacSast:
+			results.HuskyCIResults.GenericResults.HuskyCIIacSastOutput.MediumVulns = append(results.HuskyCIResults.GenericResults.HuskyCIIacSastOutput.MediumVulns, mediumVuln)
+		case wizcliVulns:
+			results.HuskyCIResults.GenericResults.HuskyCIWizCLIVulnsOutput.MediumVulns = append(results.HuskyCIResults.GenericResults.HuskyCIWizCLIVulnsOutput.MediumVulns, mediumVuln)
 		case tfsec:
 			results.HuskyCIResults.HclResults.HuskyCITFSecOutput.MediumVulns = append(results.HuskyCIResults.HclResults.HuskyCITFSecOutput.MediumVulns, mediumVuln)
 		case securitycodescan:
@@ -236,8 +248,12 @@ func (results *RunAllInfo) setVulns(securityTestScan SecTestScanInfo) {
 			results.HuskyCIResults.JavaResults.HuskyCISpotBugsOutput.LowVulns = append(results.HuskyCIResults.JavaResults.HuskyCISpotBugsOutput.LowVulns, lowVuln)
 		case gitleaks:
 			results.HuskyCIResults.GenericResults.HuskyCIGitleaksOutput.LowVulns = append(results.HuskyCIResults.GenericResults.HuskyCIGitleaksOutput.LowVulns, lowVuln)
-		case wizcli:
-			results.HuskyCIResults.GenericResults.HuskyCIWizCLIOutput.LowVulns = append(results.HuskyCIResults.GenericResults.HuskyCIWizCLIOutput.LowVulns, lowVuln)
+		case wizcliSecrets:
+			results.HuskyCIResults.GenericResults.HuskyCIWizCLISecretsOutput.LowVulns = append(results.HuskyCIResults.GenericResults.HuskyCIWizCLISecretsOutput.LowVulns, lowVuln)
+		case wizcliIacSast:
+			results.HuskyCIResults.GenericResults.HuskyCIIacSastOutput.LowVulns = append(results.HuskyCIResults.GenericResults.HuskyCIIacSastOutput.LowVulns, lowVuln)
+		case wizcliVulns:
+			results.HuskyCIResults.GenericResults.HuskyCIWizCLIVulnsOutput.LowVulns = append(results.HuskyCIResults.GenericResults.HuskyCIWizCLIVulnsOutput.LowVulns, lowVuln)
 		case tfsec:
 			results.HuskyCIResults.HclResults.HuskyCITFSecOutput.LowVulns = append(results.HuskyCIResults.HclResults.HuskyCITFSecOutput.LowVulns, lowVuln)
 		case securitycodescan:
@@ -263,8 +279,12 @@ func (results *RunAllInfo) setVulns(securityTestScan SecTestScanInfo) {
 			results.HuskyCIResults.JavaResults.HuskyCISpotBugsOutput.NoSecVulns = append(results.HuskyCIResults.JavaResults.HuskyCISpotBugsOutput.NoSecVulns, noSec)
 		case gitleaks:
 			results.HuskyCIResults.GenericResults.HuskyCIGitleaksOutput.NoSecVulns = append(results.HuskyCIResults.GenericResults.HuskyCIGitleaksOutput.NoSecVulns, noSec)
-		case wizcli:
-			results.HuskyCIResults.GenericResults.HuskyCIWizCLIOutput.NoSecVulns = append(results.HuskyCIResults.GenericResults.HuskyCIWizCLIOutput.NoSecVulns, noSec)
+		case wizcliSecrets:
+			results.HuskyCIResults.GenericResults.HuskyCIWizCLISecretsOutput.NoSecVulns = append(results.HuskyCIResults.GenericResults.HuskyCIWizCLISecretsOutput.NoSecVulns, noSec)
+		case wizcliIacSast:
+			results.HuskyCIResults.GenericResults.HuskyCIIacSastOutput.NoSecVulns = append(results.HuskyCIResults.GenericResults.HuskyCIIacSastOutput.NoSecVulns, noSec)
+		case wizcliVulns:
+			results.HuskyCIResults.GenericResults.HuskyCIWizCLIVulnsOutput.NoSecVulns = append(results.HuskyCIResults.GenericResults.HuskyCIWizCLIVulnsOutput.NoSecVulns, noSec)
 		case tfsec:
 			results.HuskyCIResults.HclResults.HuskyCITFSecOutput.NoSecVulns = append(results.HuskyCIResults.HclResults.HuskyCITFSecOutput.NoSecVulns, noSec)
 		case securitycodescan:

--- a/api/securitytest/run.go
+++ b/api/securitytest/run.go
@@ -185,7 +185,7 @@ func (results *RunAllInfo) vulnOutput(securityTestName string) *types.HuskyCISec
 		return &results.HuskyCIResults.JavaResults.HuskyCISpotBugsOutput
 	case gitleaks:
 		return &results.HuskyCIResults.GenericResults.HuskyCIGitleaksOutput
-	case wizcliSecrets:
+	case wizcliSecrets, "wizcli": // "wizcli" migration safeguard — routes to secrets output
 		return &results.HuskyCIResults.GenericResults.HuskyCIWizCLISecretsOutput
 	case wizcliIacSast:
 		return &results.HuskyCIResults.GenericResults.HuskyCIIacSastOutput

--- a/api/securitytest/run.go
+++ b/api/securitytest/run.go
@@ -166,131 +166,49 @@ func (results *RunAllInfo) runLanguageScans(ctx context.Context, enryScan SecTes
 	return g.Wait()
 }
 
+// vulnOutput maps a security test name to its corresponding HuskyCISecurityTestOutput pointer.
+func (results *RunAllInfo) vulnOutput(securityTestName string) *types.HuskyCISecurityTestOutput {
+	switch securityTestName {
+	case bandit:
+		return &results.HuskyCIResults.PythonResults.HuskyCIBanditOutput
+	case brakeman:
+		return &results.HuskyCIResults.RubyResults.HuskyCIBrakemanOutput
+	case safety:
+		return &results.HuskyCIResults.PythonResults.HuskyCISafetyOutput
+	case gosec:
+		return &results.HuskyCIResults.GoResults.HuskyCIGosecOutput
+	case npmaudit:
+		return &results.HuskyCIResults.JavaScriptResults.HuskyCINpmAuditOutput
+	case yarnaudit:
+		return &results.HuskyCIResults.JavaScriptResults.HuskyCIYarnAuditOutput
+	case spotbugs:
+		return &results.HuskyCIResults.JavaResults.HuskyCISpotBugsOutput
+	case gitleaks:
+		return &results.HuskyCIResults.GenericResults.HuskyCIGitleaksOutput
+	case wizcliSecrets:
+		return &results.HuskyCIResults.GenericResults.HuskyCIWizCLISecretsOutput
+	case wizcliIacSast:
+		return &results.HuskyCIResults.GenericResults.HuskyCIIacSastOutput
+	case wizcliVulns:
+		return &results.HuskyCIResults.GenericResults.HuskyCIWizCLIVulnsOutput
+	case tfsec:
+		return &results.HuskyCIResults.HclResults.HuskyCITFSecOutput
+	case securitycodescan:
+		return &results.HuskyCIResults.CSharpResults.HuskyCISecurityCodeScanOutput
+	default:
+		return nil
+	}
+}
+
 func (results *RunAllInfo) setVulns(securityTestScan SecTestScanInfo) {
-
-	for _, highVuln := range securityTestScan.Vulnerabilities.HighVulns {
-		switch securityTestScan.SecurityTestName {
-		case bandit:
-			results.HuskyCIResults.PythonResults.HuskyCIBanditOutput.HighVulns = append(results.HuskyCIResults.PythonResults.HuskyCIBanditOutput.HighVulns, highVuln)
-		case brakeman:
-			results.HuskyCIResults.RubyResults.HuskyCIBrakemanOutput.HighVulns = append(results.HuskyCIResults.RubyResults.HuskyCIBrakemanOutput.HighVulns, highVuln)
-		case safety:
-			results.HuskyCIResults.PythonResults.HuskyCISafetyOutput.HighVulns = append(results.HuskyCIResults.PythonResults.HuskyCISafetyOutput.HighVulns, highVuln)
-		case gosec:
-			results.HuskyCIResults.GoResults.HuskyCIGosecOutput.HighVulns = append(results.HuskyCIResults.GoResults.HuskyCIGosecOutput.HighVulns, highVuln)
-		case npmaudit:
-			results.HuskyCIResults.JavaScriptResults.HuskyCINpmAuditOutput.HighVulns = append(results.HuskyCIResults.JavaScriptResults.HuskyCINpmAuditOutput.HighVulns, highVuln)
-		case yarnaudit:
-			results.HuskyCIResults.JavaScriptResults.HuskyCIYarnAuditOutput.HighVulns = append(results.HuskyCIResults.JavaScriptResults.HuskyCIYarnAuditOutput.HighVulns, highVuln)
-		case spotbugs:
-			results.HuskyCIResults.JavaResults.HuskyCISpotBugsOutput.HighVulns = append(results.HuskyCIResults.JavaResults.HuskyCISpotBugsOutput.HighVulns, highVuln)
-		case gitleaks:
-			results.HuskyCIResults.GenericResults.HuskyCIGitleaksOutput.HighVulns = append(results.HuskyCIResults.GenericResults.HuskyCIGitleaksOutput.HighVulns, highVuln)
-		case wizcliSecrets:
-			results.HuskyCIResults.GenericResults.HuskyCIWizCLISecretsOutput.HighVulns = append(results.HuskyCIResults.GenericResults.HuskyCIWizCLISecretsOutput.HighVulns, highVuln)
-		case wizcliIacSast:
-			results.HuskyCIResults.GenericResults.HuskyCIIacSastOutput.HighVulns = append(results.HuskyCIResults.GenericResults.HuskyCIIacSastOutput.HighVulns, highVuln)
-		case wizcliVulns:
-			results.HuskyCIResults.GenericResults.HuskyCIWizCLIVulnsOutput.HighVulns = append(results.HuskyCIResults.GenericResults.HuskyCIWizCLIVulnsOutput.HighVulns, highVuln)
-		case tfsec:
-			results.HuskyCIResults.HclResults.HuskyCITFSecOutput.HighVulns = append(results.HuskyCIResults.HclResults.HuskyCITFSecOutput.HighVulns, highVuln)
-		case securitycodescan:
-			results.HuskyCIResults.CSharpResults.HuskyCISecurityCodeScanOutput.HighVulns = append(results.HuskyCIResults.CSharpResults.HuskyCISecurityCodeScanOutput.HighVulns, highVuln)
-		}
+	output := results.vulnOutput(securityTestScan.SecurityTestName)
+	if output == nil {
+		return
 	}
-
-	for _, mediumVuln := range securityTestScan.Vulnerabilities.MediumVulns {
-		switch securityTestScan.SecurityTestName {
-		case bandit:
-			results.HuskyCIResults.PythonResults.HuskyCIBanditOutput.MediumVulns = append(results.HuskyCIResults.PythonResults.HuskyCIBanditOutput.MediumVulns, mediumVuln)
-		case brakeman:
-			results.HuskyCIResults.RubyResults.HuskyCIBrakemanOutput.MediumVulns = append(results.HuskyCIResults.RubyResults.HuskyCIBrakemanOutput.MediumVulns, mediumVuln)
-		case safety:
-			results.HuskyCIResults.PythonResults.HuskyCISafetyOutput.MediumVulns = append(results.HuskyCIResults.PythonResults.HuskyCISafetyOutput.MediumVulns, mediumVuln)
-		case gosec:
-			results.HuskyCIResults.GoResults.HuskyCIGosecOutput.MediumVulns = append(results.HuskyCIResults.GoResults.HuskyCIGosecOutput.MediumVulns, mediumVuln)
-		case npmaudit:
-			results.HuskyCIResults.JavaScriptResults.HuskyCINpmAuditOutput.MediumVulns = append(results.HuskyCIResults.JavaScriptResults.HuskyCINpmAuditOutput.MediumVulns, mediumVuln)
-		case yarnaudit:
-			results.HuskyCIResults.JavaScriptResults.HuskyCIYarnAuditOutput.MediumVulns = append(results.HuskyCIResults.JavaScriptResults.HuskyCIYarnAuditOutput.MediumVulns, mediumVuln)
-		case spotbugs:
-			results.HuskyCIResults.JavaResults.HuskyCISpotBugsOutput.MediumVulns = append(results.HuskyCIResults.JavaResults.HuskyCISpotBugsOutput.MediumVulns, mediumVuln)
-		case gitleaks:
-			results.HuskyCIResults.GenericResults.HuskyCIGitleaksOutput.MediumVulns = append(results.HuskyCIResults.GenericResults.HuskyCIGitleaksOutput.MediumVulns, mediumVuln)
-		case wizcliSecrets:
-			results.HuskyCIResults.GenericResults.HuskyCIWizCLISecretsOutput.MediumVulns = append(results.HuskyCIResults.GenericResults.HuskyCIWizCLISecretsOutput.MediumVulns, mediumVuln)
-		case wizcliIacSast:
-			results.HuskyCIResults.GenericResults.HuskyCIIacSastOutput.MediumVulns = append(results.HuskyCIResults.GenericResults.HuskyCIIacSastOutput.MediumVulns, mediumVuln)
-		case wizcliVulns:
-			results.HuskyCIResults.GenericResults.HuskyCIWizCLIVulnsOutput.MediumVulns = append(results.HuskyCIResults.GenericResults.HuskyCIWizCLIVulnsOutput.MediumVulns, mediumVuln)
-		case tfsec:
-			results.HuskyCIResults.HclResults.HuskyCITFSecOutput.MediumVulns = append(results.HuskyCIResults.HclResults.HuskyCITFSecOutput.MediumVulns, mediumVuln)
-		case securitycodescan:
-			results.HuskyCIResults.CSharpResults.HuskyCISecurityCodeScanOutput.MediumVulns = append(results.HuskyCIResults.CSharpResults.HuskyCISecurityCodeScanOutput.MediumVulns, mediumVuln)
-		}
-	}
-
-	for _, lowVuln := range securityTestScan.Vulnerabilities.LowVulns {
-		switch securityTestScan.SecurityTestName {
-		case bandit:
-			results.HuskyCIResults.PythonResults.HuskyCIBanditOutput.LowVulns = append(results.HuskyCIResults.PythonResults.HuskyCIBanditOutput.LowVulns, lowVuln)
-		case brakeman:
-			results.HuskyCIResults.RubyResults.HuskyCIBrakemanOutput.LowVulns = append(results.HuskyCIResults.RubyResults.HuskyCIBrakemanOutput.LowVulns, lowVuln)
-		case safety:
-			results.HuskyCIResults.PythonResults.HuskyCISafetyOutput.LowVulns = append(results.HuskyCIResults.PythonResults.HuskyCISafetyOutput.LowVulns, lowVuln)
-		case gosec:
-			results.HuskyCIResults.GoResults.HuskyCIGosecOutput.LowVulns = append(results.HuskyCIResults.GoResults.HuskyCIGosecOutput.LowVulns, lowVuln)
-		case npmaudit:
-			results.HuskyCIResults.JavaScriptResults.HuskyCINpmAuditOutput.LowVulns = append(results.HuskyCIResults.JavaScriptResults.HuskyCINpmAuditOutput.LowVulns, lowVuln)
-		case yarnaudit:
-			results.HuskyCIResults.JavaScriptResults.HuskyCIYarnAuditOutput.LowVulns = append(results.HuskyCIResults.JavaScriptResults.HuskyCIYarnAuditOutput.LowVulns, lowVuln)
-		case spotbugs:
-			results.HuskyCIResults.JavaResults.HuskyCISpotBugsOutput.LowVulns = append(results.HuskyCIResults.JavaResults.HuskyCISpotBugsOutput.LowVulns, lowVuln)
-		case gitleaks:
-			results.HuskyCIResults.GenericResults.HuskyCIGitleaksOutput.LowVulns = append(results.HuskyCIResults.GenericResults.HuskyCIGitleaksOutput.LowVulns, lowVuln)
-		case wizcliSecrets:
-			results.HuskyCIResults.GenericResults.HuskyCIWizCLISecretsOutput.LowVulns = append(results.HuskyCIResults.GenericResults.HuskyCIWizCLISecretsOutput.LowVulns, lowVuln)
-		case wizcliIacSast:
-			results.HuskyCIResults.GenericResults.HuskyCIIacSastOutput.LowVulns = append(results.HuskyCIResults.GenericResults.HuskyCIIacSastOutput.LowVulns, lowVuln)
-		case wizcliVulns:
-			results.HuskyCIResults.GenericResults.HuskyCIWizCLIVulnsOutput.LowVulns = append(results.HuskyCIResults.GenericResults.HuskyCIWizCLIVulnsOutput.LowVulns, lowVuln)
-		case tfsec:
-			results.HuskyCIResults.HclResults.HuskyCITFSecOutput.LowVulns = append(results.HuskyCIResults.HclResults.HuskyCITFSecOutput.LowVulns, lowVuln)
-		case securitycodescan:
-			results.HuskyCIResults.CSharpResults.HuskyCISecurityCodeScanOutput.LowVulns = append(results.HuskyCIResults.CSharpResults.HuskyCISecurityCodeScanOutput.LowVulns, lowVuln)
-		}
-	}
-
-	for _, noSec := range securityTestScan.Vulnerabilities.NoSecVulns {
-		switch securityTestScan.SecurityTestName {
-		case bandit:
-			results.HuskyCIResults.PythonResults.HuskyCIBanditOutput.NoSecVulns = append(results.HuskyCIResults.PythonResults.HuskyCIBanditOutput.NoSecVulns, noSec)
-		case brakeman:
-			results.HuskyCIResults.RubyResults.HuskyCIBrakemanOutput.NoSecVulns = append(results.HuskyCIResults.RubyResults.HuskyCIBrakemanOutput.NoSecVulns, noSec)
-		case safety:
-			results.HuskyCIResults.PythonResults.HuskyCISafetyOutput.NoSecVulns = append(results.HuskyCIResults.PythonResults.HuskyCISafetyOutput.NoSecVulns, noSec)
-		case gosec:
-			results.HuskyCIResults.GoResults.HuskyCIGosecOutput.NoSecVulns = append(results.HuskyCIResults.GoResults.HuskyCIGosecOutput.NoSecVulns, noSec)
-		case npmaudit:
-			results.HuskyCIResults.JavaScriptResults.HuskyCINpmAuditOutput.NoSecVulns = append(results.HuskyCIResults.JavaScriptResults.HuskyCINpmAuditOutput.NoSecVulns, noSec)
-		case yarnaudit:
-			results.HuskyCIResults.JavaScriptResults.HuskyCIYarnAuditOutput.NoSecVulns = append(results.HuskyCIResults.JavaScriptResults.HuskyCIYarnAuditOutput.NoSecVulns, noSec)
-		case spotbugs:
-			results.HuskyCIResults.JavaResults.HuskyCISpotBugsOutput.NoSecVulns = append(results.HuskyCIResults.JavaResults.HuskyCISpotBugsOutput.NoSecVulns, noSec)
-		case gitleaks:
-			results.HuskyCIResults.GenericResults.HuskyCIGitleaksOutput.NoSecVulns = append(results.HuskyCIResults.GenericResults.HuskyCIGitleaksOutput.NoSecVulns, noSec)
-		case wizcliSecrets:
-			results.HuskyCIResults.GenericResults.HuskyCIWizCLISecretsOutput.NoSecVulns = append(results.HuskyCIResults.GenericResults.HuskyCIWizCLISecretsOutput.NoSecVulns, noSec)
-		case wizcliIacSast:
-			results.HuskyCIResults.GenericResults.HuskyCIIacSastOutput.NoSecVulns = append(results.HuskyCIResults.GenericResults.HuskyCIIacSastOutput.NoSecVulns, noSec)
-		case wizcliVulns:
-			results.HuskyCIResults.GenericResults.HuskyCIWizCLIVulnsOutput.NoSecVulns = append(results.HuskyCIResults.GenericResults.HuskyCIWizCLIVulnsOutput.NoSecVulns, noSec)
-		case tfsec:
-			results.HuskyCIResults.HclResults.HuskyCITFSecOutput.NoSecVulns = append(results.HuskyCIResults.HclResults.HuskyCITFSecOutput.NoSecVulns, noSec)
-		case securitycodescan:
-			results.HuskyCIResults.CSharpResults.HuskyCISecurityCodeScanOutput.NoSecVulns = append(results.HuskyCIResults.CSharpResults.HuskyCISecurityCodeScanOutput.NoSecVulns, noSec)
-		}
-	}
+	output.HighVulns = append(output.HighVulns, securityTestScan.Vulnerabilities.HighVulns...)
+	output.MediumVulns = append(output.MediumVulns, securityTestScan.Vulnerabilities.MediumVulns...)
+	output.LowVulns = append(output.LowVulns, securityTestScan.Vulnerabilities.LowVulns...)
+	output.NoSecVulns = append(output.NoSecVulns, securityTestScan.Vulnerabilities.NoSecVulns...)
 }
 
 // SetAnalysisError sets error on an analysis that did not got to the setToAnalysis phase

--- a/api/securitytest/securitytest.go
+++ b/api/securitytest/securitytest.go
@@ -31,6 +31,9 @@ var securityTestAnalyze = map[string]func(scanInfo *SecTestScanInfo) error{
 	"wizcli_secrets":   analyzeWizCLI,
 	"wizcli_iac_sast":  analyzeWizCLI,
 	"wizcli_vulns":     analyzeWizCLI,
+	// Migration safeguard: old "wizcli" documents may persist in MongoDB.
+	// Remove this entry after db.securityTest.deleteOne({name:"wizcli"}) is run.
+	"wizcli": analyzeWizCLI,
 }
 
 // SecTestScanInfo holds all information of securityTest scan.
@@ -155,8 +158,13 @@ func (scanInfo *SecTestScanInfo) analyze() error {
 		scanInfo.ErrorFound = errorMsg
 		return errorMsg
 	}
-	securityTestAnalyze := securityTestAnalyze[scanInfo.SecurityTestName]
-	return securityTestAnalyze(scanInfo)
+	securityTestAnalyzeFn := securityTestAnalyze[scanInfo.SecurityTestName]
+	if securityTestAnalyzeFn == nil {
+		errMsg := fmt.Errorf("unknown security test: %s", scanInfo.SecurityTestName)
+		scanInfo.ErrorFound = errMsg
+		return errMsg
+	}
+	return securityTestAnalyzeFn(scanInfo)
 }
 
 func (scanInfo *SecTestScanInfo) prepareContainerAfterScan() {

--- a/api/securitytest/securitytest.go
+++ b/api/securitytest/securitytest.go
@@ -28,7 +28,9 @@ var securityTestAnalyze = map[string]func(scanInfo *SecTestScanInfo) error{
 	"safety":           analyzeSafety,
 	"tfsec":            analyzeTFSec,
 	"securitycodescan": analyzeSecurityCodeScan,
-	"wizcli":           analyzeWizCLI,
+	"wizcli_secrets":   analyzeWizCLI,
+	"wizcli_iac_sast":  analyzeWizCLI,
+	"wizcli_vulns":     analyzeWizCLI,
 }
 
 // SecTestScanInfo holds all information of securityTest scan.

--- a/api/securitytest/wizcli.go
+++ b/api/securitytest/wizcli.go
@@ -25,7 +25,12 @@ type wizCLIReport struct {
 		OSPackages            []wizPackageWithVulns  `json:"osPackages"`
 		Secrets               []wizSecretFinding     `json:"secrets"`
 		DataFindings          []wizDataFinding       `json:"dataFindings"`
-		EndOfLifeTechnologies []wizEndOfLifeFinding  `json:"endOfLifeTechnologies"`
+		EndOfLifeTechnologies []wizEndOfLifeFinding     `json:"endOfLifeTechnologies"`
+		Iac                 []wizIacFinding           `json:"iac"`
+		Sast                []wizSastFinding          `json:"sast"`
+		Malwares            []wizMalwareFinding       `json:"malwares"`
+		AIModels            []wizAIModelFinding       `json:"aiModels"`
+		SoftwareSupplyChain []wizSupplyChainFinding   `json:"softwareSupplyChain"`
 	} `json:"result"`
 }
 
@@ -63,6 +68,46 @@ type wizDataFinding struct {
 type wizEndOfLifeFinding struct {
 	Name    string `json:"name"`
 	Version string `json:"version"`
+}
+
+type wizIacFinding struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Severity    string `json:"severity"`
+	File        string `json:"file"`
+	Line        int    `json:"line"`
+	Rule        string `json:"rule"`
+}
+
+type wizSastFinding struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Severity    string `json:"severity"`
+	File        string `json:"file"`
+	Line        int    `json:"line"`
+	Rule        string `json:"rule"`
+}
+
+type wizMalwareFinding struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Severity    string `json:"severity"`
+	Path        string `json:"path"`
+}
+
+type wizAIModelFinding struct {
+	Name     string `json:"name"`
+	Version  string `json:"version"`
+	Severity string `json:"severity"`
+	Path     string `json:"path"`
+}
+
+type wizSupplyChainFinding struct {
+	Name     string `json:"name"`
+	Version  string `json:"version"`
+	Severity string `json:"severity"`
+	License  string `json:"license"`
+	Path     string `json:"path"`
 }
 
 func analyzeWizCLI(scanInfo *SecTestScanInfo) error {
@@ -426,6 +471,65 @@ func parseWizCLIJSON(output string) ([]types.HuskyCIVulnerability, error) {
 			location += ":" + eol.Version
 		}
 		addFinding("End of Life Technology", "MEDIUM", location, "", eol.Name+" is end of life")
+	}
+
+	for _, finding := range report.Result.Iac {
+		title := finding.Name
+		if title == "" {
+			title = finding.Rule
+		}
+		severity := strings.ToUpper(finding.Severity)
+		if severity == "" {
+			severity = "MEDIUM"
+		}
+		line := ""
+		if finding.Line > 0 {
+			line = strconv.Itoa(finding.Line)
+		}
+		addFinding(title, severity, util.NormalizeFilePath(finding.File), line, finding.Description)
+	}
+
+	for _, finding := range report.Result.Sast {
+		title := finding.Name
+		if title == "" {
+			title = finding.Rule
+		}
+		severity := strings.ToUpper(finding.Severity)
+		if severity == "" {
+			severity = "MEDIUM"
+		}
+		line := ""
+		if finding.Line > 0 {
+			line = strconv.Itoa(finding.Line)
+		}
+		addFinding(title, severity, util.NormalizeFilePath(finding.File), line, finding.Description)
+	}
+
+	for _, finding := range report.Result.Malwares {
+		title := finding.Name
+		severity := strings.ToUpper(finding.Severity)
+		if severity == "" {
+			severity = "HIGH"
+		}
+		addFinding(title, severity, util.NormalizeFilePath(finding.Path), "", finding.Description)
+	}
+
+	for _, finding := range report.Result.AIModels {
+		title := finding.Name
+		severity := strings.ToUpper(finding.Severity)
+		if severity == "" {
+			severity = "INFO"
+		}
+		addFinding(title, severity, util.NormalizeFilePath(finding.Path), "", fmt.Sprintf("%s:%s", finding.Name, finding.Version))
+	}
+
+	for _, finding := range report.Result.SoftwareSupplyChain {
+		title := finding.Name
+		severity := strings.ToUpper(finding.Severity)
+		if severity == "" {
+			severity = "MEDIUM"
+		}
+		addFinding(title, severity, util.NormalizeFilePath(finding.Path), "", fmt.Sprintf("%s:%s (license: %s)", finding.Name, finding.Version, finding.License))
 	}
 
 	return findings, nil

--- a/api/securitytest/wizcli.go
+++ b/api/securitytest/wizcli.go
@@ -12,7 +12,7 @@ import (
 	"github.com/githubanotaai/huskyci-api/api/util"
 )
 
-// wizCLIReport models the subset of `wizcli dir scan -f json` output that
+// wizCLIReport models the subset of `wizcli scan dir --stdout=json` output that
 // huskyCI surfaces as findings. Unrelated metadata (analytics, sbomOutput,
 // hostConfiguration, ...) is intentionally ignored.
 type wizCLIReport struct {
@@ -119,7 +119,7 @@ func analyzeWizCLI(scanInfo *SecTestScanInfo) error {
 	}
 
 	if strings.Contains(output, "ERROR_RUNNING_WIZCLI_SCAN") {
-		scanInfo.ErrorFound = errors.New("wizcli dir scan failed with a non-findings exit code")
+		scanInfo.ErrorFound = errors.New("wizcli scan dir failed with a non-findings exit code")
 		return scanInfo.ErrorFound
 	}
 
@@ -361,7 +361,7 @@ func generateSonarQubeExternalIssue(vuln types.HuskyCIVulnerability) sonarQubeEx
 	return issue
 }
 
-// parseWizCLIJSON converts the JSON produced by `wizcli dir scan -f json`
+// parseWizCLIJSON converts the JSON produced by `wizcli scan dir --stdout=json`
 // into HuskyCIVulnerability entries, covering CVEs (libraries, OS packages),
 // secrets, data findings, and end-of-life technologies.
 func parseWizCLIJSON(output string) ([]types.HuskyCIVulnerability, error) {

--- a/api/securitytest/wizcli.go
+++ b/api/securitytest/wizcli.go
@@ -26,8 +26,8 @@ type wizCLIReport struct {
 		Secrets               []wizSecretFinding     `json:"secrets"`
 		DataFindings          []wizDataFinding       `json:"dataFindings"`
 		EndOfLifeTechnologies []wizEndOfLifeFinding     `json:"endOfLifeTechnologies"`
-		Iac                 []wizIacFinding           `json:"iac"`
-		Sast                []wizSastFinding          `json:"sast"`
+		Iac                 []wizCodeFinding          `json:"iac"`
+		Sast                []wizCodeFinding          `json:"sast"`
 		Malwares            []wizMalwareFinding       `json:"malwares"`
 		AIModels            []wizAIModelFinding       `json:"aiModels"`
 		SoftwareSupplyChain []wizSupplyChainFinding   `json:"softwareSupplyChain"`
@@ -70,16 +70,7 @@ type wizEndOfLifeFinding struct {
 	Version string `json:"version"`
 }
 
-type wizIacFinding struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	Severity    string `json:"severity"`
-	File        string `json:"file"`
-	Line        int    `json:"line"`
-	Rule        string `json:"rule"`
-}
-
-type wizSastFinding struct {
+type wizCodeFinding struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
 	Severity    string `json:"severity"`
@@ -473,37 +464,26 @@ func parseWizCLIJSON(output string) ([]types.HuskyCIVulnerability, error) {
 		addFinding("End of Life Technology", "MEDIUM", location, "", eol.Name+" is end of life")
 	}
 
-	for _, finding := range report.Result.Iac {
-		title := finding.Name
-		if title == "" {
-			title = finding.Rule
+	collectCodeFindings := func(findings []wizCodeFinding) {
+		for _, finding := range findings {
+			title := finding.Name
+			if title == "" {
+				title = finding.Rule
+			}
+			severity := strings.ToUpper(finding.Severity)
+			if severity == "" {
+				severity = "MEDIUM"
+			}
+			line := ""
+			if finding.Line > 0 {
+				line = strconv.Itoa(finding.Line)
+			}
+			addFinding(title, severity, util.NormalizeFilePath(finding.File), line, finding.Description)
 		}
-		severity := strings.ToUpper(finding.Severity)
-		if severity == "" {
-			severity = "MEDIUM"
-		}
-		line := ""
-		if finding.Line > 0 {
-			line = strconv.Itoa(finding.Line)
-		}
-		addFinding(title, severity, util.NormalizeFilePath(finding.File), line, finding.Description)
 	}
 
-	for _, finding := range report.Result.Sast {
-		title := finding.Name
-		if title == "" {
-			title = finding.Rule
-		}
-		severity := strings.ToUpper(finding.Severity)
-		if severity == "" {
-			severity = "MEDIUM"
-		}
-		line := ""
-		if finding.Line > 0 {
-			line = strconv.Itoa(finding.Line)
-		}
-		addFinding(title, severity, util.NormalizeFilePath(finding.File), line, finding.Description)
-	}
+	collectCodeFindings(report.Result.Iac)
+	collectCodeFindings(report.Result.Sast)
 
 	for _, finding := range report.Result.Malwares {
 		title := finding.Name

--- a/api/securitytest/wizcli_test.go
+++ b/api/securitytest/wizcli_test.go
@@ -178,6 +178,162 @@ func TestParseWizCLIJSON_EOLTechnologies(t *testing.T) {
 	}
 }
 
+func TestParseWizCLIJSON_IacFindings(t *testing.T) {
+	const input = `{"result":{"iac":[
+		{"name":"S3 Bucket without versioning","description":"Bucket should have versioning","severity":"HIGH","file":"main.tf","line":42,"rule":"CKV_AWS_1"}
+	]}}`
+	out, err := parseWizCLIJSON(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("expected 1 IaC finding, got %d", len(out))
+	}
+	v := out[0]
+	if v.Title != "S3 Bucket without versioning" {
+		t.Errorf("expected Title 'S3 Bucket without versioning', got %q", v.Title)
+	}
+	if v.Severity != "HIGH" {
+		t.Errorf("expected Severity HIGH, got %q", v.Severity)
+	}
+	if v.File != "main.tf" {
+		t.Errorf("expected File 'main.tf', got %q", v.File)
+	}
+	if v.Line != "42" {
+		t.Errorf("expected Line '42', got %q", v.Line)
+	}
+	if v.Details != "Bucket should have versioning" {
+		t.Errorf("expected Details 'Bucket should have versioning', got %q", v.Details)
+	}
+	if v.SecurityTool != "WizCLI" {
+		t.Errorf("expected SecurityTool WizCLI, got %q", v.SecurityTool)
+	}
+}
+
+func TestParseWizCLIJSON_SastFindings(t *testing.T) {
+	const input = `{"result":{"sast":[
+		{"name":"SQL Injection","description":"Unsanitized input in SQL query","severity":"CRITICAL","file":"handler.go","line":100,"rule":"SQL_INJECTION"}
+	]}}`
+	out, err := parseWizCLIJSON(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("expected 1 SAST finding, got %d", len(out))
+	}
+	v := out[0]
+	if v.Title != "SQL Injection" {
+		t.Errorf("expected Title 'SQL Injection', got %q", v.Title)
+	}
+	if v.Severity != "CRITICAL" {
+		t.Errorf("expected Severity CRITICAL, got %q", v.Severity)
+	}
+	if v.File != "handler.go" {
+		t.Errorf("expected File 'handler.go', got %q", v.File)
+	}
+	if v.Line != "100" {
+		t.Errorf("expected Line '100', got %q", v.Line)
+	}
+	if v.Details != "Unsanitized input in SQL query" {
+		t.Errorf("expected Details 'Unsanitized input in SQL query', got %q", v.Details)
+	}
+}
+
+func TestParseWizCLIJSON_MalwareFindings(t *testing.T) {
+	const input = `{"result":{"malwares":[
+		{"name":"Trojan.GenericKD","description":"Known malware detected","severity":"HIGH","path":"vendor/evil/lib.so"}
+	]}}`
+	out, err := parseWizCLIJSON(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("expected 1 Malware finding, got %d", len(out))
+	}
+	v := out[0]
+	if v.Title != "Trojan.GenericKD" {
+		t.Errorf("expected Title 'Trojan.GenericKD', got %q", v.Title)
+	}
+	if v.Severity != "HIGH" {
+		t.Errorf("expected Severity HIGH, got %q", v.Severity)
+	}
+	if v.File != "vendor/evil/lib.so" {
+		t.Errorf("expected File (Code/Path) 'vendor/evil/lib.so', got %q", v.File)
+	}
+	if v.Line != "" {
+		t.Errorf("expected Line '' (line=0 in JSON), got %q", v.Line)
+	}
+	if v.Details != "Known malware detected" {
+		t.Errorf("expected Details 'Known malware detected', got %q", v.Details)
+	}
+}
+
+func TestParseWizCLIJSON_AIModelFindings(t *testing.T) {
+	const input = `{"result":{"aiModels":[
+		{"name":"gpt-4","version":"2024-03","severity":"INFO","path":"requirements.txt"}
+	]}}`
+	out, err := parseWizCLIJSON(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("expected 1 AIModel finding, got %d", len(out))
+	}
+	v := out[0]
+	if v.Title != "gpt-4" {
+		t.Errorf("expected Title 'gpt-4', got %q", v.Title)
+	}
+	if v.Severity != "INFO" {
+		t.Errorf("expected Severity INFO, got %q", v.Severity)
+	}
+	if v.File != "requirements.txt" {
+		t.Errorf("expected File (Path) 'requirements.txt', got %q", v.File)
+	}
+	if !strings.Contains(v.Details, "gpt-4:2024-03") {
+		t.Errorf("expected Details to contain 'gpt-4:2024-03', got %q", v.Details)
+	}
+}
+
+func TestParseWizCLIJSON_SoftwareSupplyChainFindings(t *testing.T) {
+	const input = `{"result":{"softwareSupplyChain":[
+		{"name":"lodash","version":"4.17.20","severity":"MEDIUM","license":"MIT","path":"package.json"}
+	]}}`
+	out, err := parseWizCLIJSON(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("expected 1 Supply Chain finding, got %d", len(out))
+	}
+	v := out[0]
+	if v.Title != "lodash" {
+		t.Errorf("expected Title 'lodash', got %q", v.Title)
+	}
+	if v.Severity != "MEDIUM" {
+		t.Errorf("expected Severity MEDIUM, got %q", v.Severity)
+	}
+	if v.File != "package.json" {
+		t.Errorf("expected File (Path) 'package.json', got %q", v.File)
+	}
+	if !strings.Contains(v.Details, "lodash:4.17.20") {
+		t.Errorf("expected Details to contain 'lodash:4.17.20', got %q", v.Details)
+	}
+	if !strings.Contains(v.Details, "license: MIT") {
+		t.Errorf("expected Details to contain 'license: MIT', got %q", v.Details)
+	}
+}
+
+func TestParseWizCLIJSON_NullNewFieldsIsNoError(t *testing.T) {
+	const input = `{"result":{"iac":null,"sast":null,"malwares":null,"aiModels":null,"softwareSupplyChain":null}}`
+	out, err := parseWizCLIJSON(input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out) != 0 {
+		t.Errorf("expected 0 findings with null new fields, got %d", len(out))
+	}
+}
+
 func TestParseWizCLIJSON_Deduplicates(t *testing.T) {
 	const input = `{"result":{"libraries":[
 		{"name":"lodash","version":"4.17.4","path":"/package-lock.json",

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -134,7 +134,7 @@ type RubyResults struct {
 type GenericResults struct {
 	HuskyCIGitleaksOutput  HuskyCISecurityTestOutput `bson:"gitleaksoutput,omitempty" json:"gitleaksoutput,omitempty"`
 	HuskyCIWizCLISecretsOutput HuskyCISecurityTestOutput `bson:"wizclisecretsoutput,omitempty" json:"wizclisecretsoutput,omitempty"`
-	HuskyCIIacSastOutput       HuskyCISecurityTestOutput `bson:"iavsastoutput,omitempty" json:"iavsastoutput,omitempty"`
+	HuskyCIIacSastOutput       HuskyCISecurityTestOutput `bson:"iacsastoutput,omitempty" json:"iacsastoutput,omitempty"`
 	HuskyCIWizCLIVulnsOutput   HuskyCISecurityTestOutput `bson:"wizclivulnsoutput,omitempty" json:"wizclivulnsoutput,omitempty"`
 }
 

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -133,7 +133,9 @@ type RubyResults struct {
 // GenericResults represents all generic securityTests results
 type GenericResults struct {
 	HuskyCIGitleaksOutput  HuskyCISecurityTestOutput `bson:"gitleaksoutput,omitempty" json:"gitleaksoutput,omitempty"`
-	HuskyCIWizCLIOutput    HuskyCISecurityTestOutput `bson:"wizclioutput,omitempty" json:"wizclioutput,omitempty"`
+	HuskyCIWizCLISecretsOutput HuskyCISecurityTestOutput `bson:"wizclisecretsoutput,omitempty" json:"wizclisecretsoutput,omitempty"`
+	HuskyCIIacSastOutput       HuskyCISecurityTestOutput `bson:"iavsastoutput,omitempty" json:"iavsastoutput,omitempty"`
+	HuskyCIWizCLIVulnsOutput   HuskyCISecurityTestOutput `bson:"wizclivulnsoutput,omitempty" json:"wizclivulnsoutput,omitempty"`
 }
 
 // HclResults represents all HCL security tests results.

--- a/api/util/api/api.go
+++ b/api/util/api/api.go
@@ -160,7 +160,7 @@ func (cH *CheckUtils) checkEachSecurityTest(configAPI *apiContext.APIConfig) err
 	securityTests := []string{
 		"enry", "gitauthors", "gosec", "brakeman", "bandit",
 		"npmaudit", "yarnaudit", "spotbugs", "gitleaks", "safety",
-		"tfsec", "securitycodescan", "wizcli",
+		"tfsec", "securitycodescan", "wizcli_secrets", "wizcli_iac_sast", "wizcli_vulns",
 	}
 	for _, securityTest := range securityTests {
 		if err := checkSecurityTest(securityTest, configAPI); err != nil {
@@ -228,8 +228,12 @@ func checkSecurityTest(securityTestName string, configAPI *apiContext.APIConfig)
 		securityTestConfig = *configAPI.TFSecSecurityTest
 	case "securitycodescan":
 		securityTestConfig = *configAPI.SecurityCodeScanSecurityTest
-	case "wizcli":
-		securityTestConfig = *configAPI.WizcliSecurityTest
+	case "wizcli_secrets":
+		securityTestConfig = *configAPI.WizcliSecretsSecurityTest
+	case "wizcli_iac_sast":
+		securityTestConfig = *configAPI.WizcliIacSastSecurityTest
+	case "wizcli_vulns":
+		securityTestConfig = *configAPI.WizcliVulnsSecurityTest
 	default:
 		return errors.New("securityTest name not defined")
 	}

--- a/api/util/api/api_test.go
+++ b/api/util/api/api_test.go
@@ -117,14 +117,20 @@ var _ = Describe("Util API", func() {
 		})
 	})
 
-	Describe("APIConfig WizcliSecurityTest wiring", func() {
-		Context("When WizcliSecurityTest is provided in configAPI", func() {
-			It("WizcliSecurityTest should be non-nil when provided in configAPI", func() {
+	Describe("APIConfig WizCLI split security test wiring", func() {
+		Context("When WizCLI split security tests are provided in configAPI", func() {
+			It("WizCLI split security tests should be non-nil when provided in configAPI", func() {
 				cfg := &apiContext.APIConfig{
-					WizcliSecurityTest: &types.SecurityTest{Name: "wizcli"},
+					WizcliSecretsSecurityTest: &types.SecurityTest{Name: "wizcli_secrets"},
+					WizcliIacSastSecurityTest:  &types.SecurityTest{Name: "wizcli_iac_sast"},
+					WizcliVulnsSecurityTest:   &types.SecurityTest{Name: "wizcli_vulns"},
 				}
-				Expect(cfg.WizcliSecurityTest).NotTo(BeNil())
-				Expect(cfg.WizcliSecurityTest.Name).To(Equal("wizcli"))
+				Expect(cfg.WizcliSecretsSecurityTest).NotTo(BeNil())
+				Expect(cfg.WizcliSecretsSecurityTest.Name).To(Equal("wizcli_secrets"))
+				Expect(cfg.WizcliIacSastSecurityTest).NotTo(BeNil())
+				Expect(cfg.WizcliIacSastSecurityTest.Name).To(Equal("wizcli_iac_sast"))
+				Expect(cfg.WizcliVulnsSecurityTest).NotTo(BeNil())
+				Expect(cfg.WizcliVulnsSecurityTest.Name).To(Equal("wizcli_vulns"))
 			})
 		})
 	})

--- a/client/analysis/output.go
+++ b/client/analysis/output.go
@@ -269,7 +269,7 @@ func prepareAllSummary(analysis types.Analysis) {
 
 func printAllSummary(analysis types.Analysis) {
 
-	var gosecVersion, banditVersion, safetyVersion, brakemanVersion, npmauditVersion, yarnauditVersion, gitleaksVersion, wizcliVersion, spotbugsVersion, tfsecVersion, securityCodeScanVersion string
+	var gosecVersion, banditVersion, safetyVersion, brakemanVersion, npmauditVersion, yarnauditVersion, gitleaksVersion, wizcliSecretsVersion, wizcliIacSastVersion, wizcliVulnsVersion, spotbugsVersion, tfsecVersion, securityCodeScanVersion string
 
 	for _, container := range analysis.Containers {
 		switch container.SecurityTest.Name {
@@ -289,8 +289,12 @@ func printAllSummary(analysis types.Analysis) {
 			spotbugsVersion = fmt.Sprintf("%s:%s", container.SecurityTest.Image, container.SecurityTest.ImageTag)
 		case "gitleaks":
 			gitleaksVersion = fmt.Sprintf("%s:%s", container.SecurityTest.Image, container.SecurityTest.ImageTag)
-		case "wizcli_secrets", "wizcli_iac_sast", "wizcli_vulns":
-			wizcliVersion = fmt.Sprintf("%s:%s", container.SecurityTest.Image, container.SecurityTest.ImageTag)
+		case "wizcli_secrets":
+			wizcliSecretsVersion = fmt.Sprintf("%s:%s", container.SecurityTest.Image, container.SecurityTest.ImageTag)
+		case "wizcli_iac_sast":
+			wizcliIacSastVersion = fmt.Sprintf("%s:%s", container.SecurityTest.Image, container.SecurityTest.ImageTag)
+		case "wizcli_vulns":
+			wizcliVulnsVersion = fmt.Sprintf("%s:%s", container.SecurityTest.Image, container.SecurityTest.ImageTag)
 		case "tfsec":
 			tfsecVersion = fmt.Sprintf("%s:%s", container.SecurityTest.Image, container.SecurityTest.ImageTag)
 		case "securitycodescan":
@@ -390,7 +394,7 @@ func printAllSummary(analysis types.Analysis) {
 
 	if outputJSON.Summary.WizCLISecretsSummary.FoundVuln || outputJSON.Summary.WizCLISecretsSummary.FoundInfo {
 		fmt.Println()
-		fmt.Printf("[HUSKYCI][SUMMARY] Generic -> %s\n", wizcliVersion)
+		fmt.Printf("[HUSKYCI][SUMMARY] Generic -> %s\n", wizcliSecretsVersion)
 		fmt.Printf("[HUSKYCI][SUMMARY] Wiz CLI (Secrets) High: %d\n", outputJSON.Summary.WizCLISecretsSummary.HighVuln)
 		fmt.Printf("[HUSKYCI][SUMMARY] Wiz CLI (Secrets) Medium: %d\n", outputJSON.Summary.WizCLISecretsSummary.MediumVuln)
 		fmt.Printf("[HUSKYCI][SUMMARY] Wiz CLI (Secrets) Low: %d\n", outputJSON.Summary.WizCLISecretsSummary.LowVuln)
@@ -399,7 +403,7 @@ func printAllSummary(analysis types.Analysis) {
 
 	if outputJSON.Summary.WizCLIIacSastSummary.FoundVuln || outputJSON.Summary.WizCLIIacSastSummary.FoundInfo {
 		fmt.Println()
-		fmt.Printf("[HUSKYCI][SUMMARY] Generic -> %s\n", wizcliVersion)
+		fmt.Printf("[HUSKYCI][SUMMARY] Generic -> %s\n", wizcliIacSastVersion)
 		fmt.Printf("[HUSKYCI][SUMMARY] Wiz CLI (IaC+SAST) High: %d\n", outputJSON.Summary.WizCLIIacSastSummary.HighVuln)
 		fmt.Printf("[HUSKYCI][SUMMARY] Wiz CLI (IaC+SAST) Medium: %d\n", outputJSON.Summary.WizCLIIacSastSummary.MediumVuln)
 		fmt.Printf("[HUSKYCI][SUMMARY] Wiz CLI (IaC+SAST) Low: %d\n", outputJSON.Summary.WizCLIIacSastSummary.LowVuln)
@@ -408,7 +412,7 @@ func printAllSummary(analysis types.Analysis) {
 
 	if outputJSON.Summary.WizCLIVulnsSummary.FoundVuln || outputJSON.Summary.WizCLIVulnsSummary.FoundInfo {
 		fmt.Println()
-		fmt.Printf("[HUSKYCI][SUMMARY] Generic -> %s\n", wizcliVersion)
+		fmt.Printf("[HUSKYCI][SUMMARY] Generic -> %s\n", wizcliVulnsVersion)
 		fmt.Printf("[HUSKYCI][SUMMARY] Wiz CLI (Vulns) High: %d\n", outputJSON.Summary.WizCLIVulnsSummary.HighVuln)
 		fmt.Printf("[HUSKYCI][SUMMARY] Wiz CLI (Vulns) Medium: %d\n", outputJSON.Summary.WizCLIVulnsSummary.MediumVuln)
 		fmt.Printf("[HUSKYCI][SUMMARY] Wiz CLI (Vulns) Low: %d\n", outputJSON.Summary.WizCLIVulnsSummary.LowVuln)

--- a/client/analysis/output.go
+++ b/client/analysis/output.go
@@ -52,7 +52,9 @@ func printSTDOUTOutput(analysis types.Analysis) {
 	printToolGroup("Generic - Gitleaks", outputJSON.GenericResults.HuskyCIGitleaksOutput, printSTDOUTOutputGitleaks)
 
 	// wizcli
-	printToolGroup("Generic - Wiz CLI", outputJSON.GenericResults.HuskyCIWizCLIOutput, printSTDOUTOutputWizCLI)
+	printToolGroup("Generic - Wiz CLI (Secrets)", outputJSON.GenericResults.HuskyCIWizCLISecretsOutput, printSTDOUTOutputWizCLI)
+	printToolGroup("Generic - Wiz CLI (IaC+SAST)", outputJSON.GenericResults.HuskyCIIacSastOutput, printSTDOUTOutputWizCLI)
+	printToolGroup("Generic - Wiz CLI (Vulns)", outputJSON.GenericResults.HuskyCIWizCLIVulnsOutput, printSTDOUTOutputWizCLI)
 
 	// spotbugs
 	printToolGroup("Java - SpotBugs", outputJSON.JavaResults.HuskyCISpotBugsOutput, printSTDOUTOutputSpotBugs)
@@ -183,16 +185,40 @@ func prepareAllSummary(analysis types.Analysis) {
 		outputJSON.Summary.GitleaksSummary.FoundVuln = true
 	}
 
-	// WizCLI summary
-	outputJSON.Summary.WizCLISummary.NoSecVuln = len(outputJSON.GenericResults.HuskyCIWizCLIOutput.NoSecVulns)
-	outputJSON.Summary.WizCLISummary.LowVuln = len(outputJSON.GenericResults.HuskyCIWizCLIOutput.LowVulns)
-	outputJSON.Summary.WizCLISummary.MediumVuln = len(outputJSON.GenericResults.HuskyCIWizCLIOutput.MediumVulns)
-	outputJSON.Summary.WizCLISummary.HighVuln = len(outputJSON.GenericResults.HuskyCIWizCLIOutput.HighVulns)
-	if len(outputJSON.GenericResults.HuskyCIWizCLIOutput.LowVulns) > 0 || len(outputJSON.GenericResults.HuskyCIWizCLIOutput.NoSecVulns) > 0 {
-		outputJSON.Summary.WizCLISummary.FoundInfo = true
+	// WizCLI Secrets summary
+	outputJSON.Summary.WizCLISecretsSummary.NoSecVuln = len(outputJSON.GenericResults.HuskyCIWizCLISecretsOutput.NoSecVulns)
+	outputJSON.Summary.WizCLISecretsSummary.LowVuln = len(outputJSON.GenericResults.HuskyCIWizCLISecretsOutput.LowVulns)
+	outputJSON.Summary.WizCLISecretsSummary.MediumVuln = len(outputJSON.GenericResults.HuskyCIWizCLISecretsOutput.MediumVulns)
+	outputJSON.Summary.WizCLISecretsSummary.HighVuln = len(outputJSON.GenericResults.HuskyCIWizCLISecretsOutput.HighVulns)
+	if len(outputJSON.GenericResults.HuskyCIWizCLISecretsOutput.LowVulns) > 0 || len(outputJSON.GenericResults.HuskyCIWizCLISecretsOutput.NoSecVulns) > 0 {
+		outputJSON.Summary.WizCLISecretsSummary.FoundInfo = true
 	}
-	if len(outputJSON.GenericResults.HuskyCIWizCLIOutput.MediumVulns) > 0 || len(outputJSON.GenericResults.HuskyCIWizCLIOutput.HighVulns) > 0 {
-		outputJSON.Summary.WizCLISummary.FoundVuln = true
+	if len(outputJSON.GenericResults.HuskyCIWizCLISecretsOutput.MediumVulns) > 0 || len(outputJSON.GenericResults.HuskyCIWizCLISecretsOutput.HighVulns) > 0 {
+		outputJSON.Summary.WizCLISecretsSummary.FoundVuln = true
+	}
+
+	// WizCLI IaC+SAST summary
+	outputJSON.Summary.WizCLIIacSastSummary.NoSecVuln = len(outputJSON.GenericResults.HuskyCIIacSastOutput.NoSecVulns)
+	outputJSON.Summary.WizCLIIacSastSummary.LowVuln = len(outputJSON.GenericResults.HuskyCIIacSastOutput.LowVulns)
+	outputJSON.Summary.WizCLIIacSastSummary.MediumVuln = len(outputJSON.GenericResults.HuskyCIIacSastOutput.MediumVulns)
+	outputJSON.Summary.WizCLIIacSastSummary.HighVuln = len(outputJSON.GenericResults.HuskyCIIacSastOutput.HighVulns)
+	if len(outputJSON.GenericResults.HuskyCIIacSastOutput.LowVulns) > 0 || len(outputJSON.GenericResults.HuskyCIIacSastOutput.NoSecVulns) > 0 {
+		outputJSON.Summary.WizCLIIacSastSummary.FoundInfo = true
+	}
+	if len(outputJSON.GenericResults.HuskyCIIacSastOutput.MediumVulns) > 0 || len(outputJSON.GenericResults.HuskyCIIacSastOutput.HighVulns) > 0 {
+		outputJSON.Summary.WizCLIIacSastSummary.FoundVuln = true
+	}
+
+	// WizCLI Vulns summary
+	outputJSON.Summary.WizCLIVulnsSummary.NoSecVuln = len(outputJSON.GenericResults.HuskyCIWizCLIVulnsOutput.NoSecVulns)
+	outputJSON.Summary.WizCLIVulnsSummary.LowVuln = len(outputJSON.GenericResults.HuskyCIWizCLIVulnsOutput.LowVulns)
+	outputJSON.Summary.WizCLIVulnsSummary.MediumVuln = len(outputJSON.GenericResults.HuskyCIWizCLIVulnsOutput.MediumVulns)
+	outputJSON.Summary.WizCLIVulnsSummary.HighVuln = len(outputJSON.GenericResults.HuskyCIWizCLIVulnsOutput.HighVulns)
+	if len(outputJSON.GenericResults.HuskyCIWizCLIVulnsOutput.LowVulns) > 0 || len(outputJSON.GenericResults.HuskyCIWizCLIVulnsOutput.NoSecVulns) > 0 {
+		outputJSON.Summary.WizCLIVulnsSummary.FoundInfo = true
+	}
+	if len(outputJSON.GenericResults.HuskyCIWizCLIVulnsOutput.MediumVulns) > 0 || len(outputJSON.GenericResults.HuskyCIWizCLIVulnsOutput.HighVulns) > 0 {
+		outputJSON.Summary.WizCLIVulnsSummary.FoundVuln = true
 	}
 
 	// TFSec summary
@@ -218,21 +244,21 @@ func prepareAllSummary(analysis types.Analysis) {
 	}
 
 	// Total summary
-	if outputJSON.Summary.GosecSummary.FoundVuln || outputJSON.Summary.BanditSummary.FoundVuln || outputJSON.Summary.SafetySummary.FoundVuln || outputJSON.Summary.BrakemanSummary.FoundVuln || outputJSON.Summary.NpmAuditSummary.FoundVuln || outputJSON.Summary.YarnAuditSummary.FoundVuln || outputJSON.Summary.GitleaksSummary.FoundVuln || outputJSON.Summary.WizCLISummary.FoundVuln || outputJSON.Summary.SpotBugsSummary.FoundVuln || outputJSON.Summary.TFSecSummary.FoundVuln || outputJSON.Summary.SecurityCodeScanSummary.FoundVuln {
+	if outputJSON.Summary.GosecSummary.FoundVuln || outputJSON.Summary.BanditSummary.FoundVuln || outputJSON.Summary.SafetySummary.FoundVuln || outputJSON.Summary.BrakemanSummary.FoundVuln || outputJSON.Summary.NpmAuditSummary.FoundVuln || outputJSON.Summary.YarnAuditSummary.FoundVuln || outputJSON.Summary.GitleaksSummary.FoundVuln || outputJSON.Summary.WizCLISecretsSummary.FoundVuln || outputJSON.Summary.WizCLIIacSastSummary.FoundVuln || outputJSON.Summary.WizCLIVulnsSummary.FoundVuln || outputJSON.Summary.SpotBugsSummary.FoundVuln || outputJSON.Summary.TFSecSummary.FoundVuln || outputJSON.Summary.SecurityCodeScanSummary.FoundVuln {
 		outputJSON.Summary.TotalSummary.FoundVuln = true
 		types.FoundVuln = true
-	} else if outputJSON.Summary.GosecSummary.FoundInfo || outputJSON.Summary.BanditSummary.FoundInfo || outputJSON.Summary.SafetySummary.FoundInfo || outputJSON.Summary.BrakemanSummary.FoundInfo || outputJSON.Summary.NpmAuditSummary.FoundInfo || outputJSON.Summary.YarnAuditSummary.FoundInfo || outputJSON.Summary.GitleaksSummary.FoundInfo || outputJSON.Summary.WizCLISummary.FoundInfo || outputJSON.Summary.SpotBugsSummary.FoundInfo || outputJSON.Summary.TFSecSummary.FoundInfo || outputJSON.Summary.SecurityCodeScanSummary.FoundInfo {
+	} else if outputJSON.Summary.GosecSummary.FoundInfo || outputJSON.Summary.BanditSummary.FoundInfo || outputJSON.Summary.SafetySummary.FoundInfo || outputJSON.Summary.BrakemanSummary.FoundInfo || outputJSON.Summary.NpmAuditSummary.FoundInfo || outputJSON.Summary.YarnAuditSummary.FoundInfo || outputJSON.Summary.GitleaksSummary.FoundInfo || outputJSON.Summary.WizCLISecretsSummary.FoundInfo || outputJSON.Summary.WizCLIIacSastSummary.FoundInfo || outputJSON.Summary.WizCLIVulnsSummary.FoundInfo || outputJSON.Summary.SpotBugsSummary.FoundInfo || outputJSON.Summary.TFSecSummary.FoundInfo || outputJSON.Summary.SecurityCodeScanSummary.FoundInfo {
 		outputJSON.Summary.TotalSummary.FoundInfo = true
 		types.FoundInfo = true
 	}
 
-	totalNoSec = outputJSON.Summary.BrakemanSummary.NoSecVuln + outputJSON.Summary.BanditSummary.NoSecVuln + outputJSON.Summary.GosecSummary.NoSecVuln + outputJSON.Summary.GitleaksSummary.NoSecVuln + outputJSON.Summary.WizCLISummary.NoSecVuln
+	totalNoSec = outputJSON.Summary.BrakemanSummary.NoSecVuln + outputJSON.Summary.BanditSummary.NoSecVuln + outputJSON.Summary.GosecSummary.NoSecVuln + outputJSON.Summary.GitleaksSummary.NoSecVuln + outputJSON.Summary.WizCLISecretsSummary.NoSecVuln + outputJSON.Summary.WizCLIIacSastSummary.NoSecVuln + outputJSON.Summary.WizCLIVulnsSummary.NoSecVuln
 
-	totalLow = outputJSON.Summary.BrakemanSummary.LowVuln + outputJSON.Summary.SafetySummary.LowVuln + outputJSON.Summary.BanditSummary.LowVuln + outputJSON.Summary.GosecSummary.LowVuln + outputJSON.Summary.NpmAuditSummary.LowVuln + outputJSON.Summary.YarnAuditSummary.LowVuln + outputJSON.Summary.GitleaksSummary.LowVuln + outputJSON.Summary.WizCLISummary.LowVuln + outputJSON.Summary.SpotBugsSummary.LowVuln + outputJSON.Summary.TFSecSummary.LowVuln + outputJSON.Summary.SecurityCodeScanSummary.LowVuln
+	totalLow = outputJSON.Summary.BrakemanSummary.LowVuln + outputJSON.Summary.SafetySummary.LowVuln + outputJSON.Summary.BanditSummary.LowVuln + outputJSON.Summary.GosecSummary.LowVuln + outputJSON.Summary.NpmAuditSummary.LowVuln + outputJSON.Summary.YarnAuditSummary.LowVuln + outputJSON.Summary.GitleaksSummary.LowVuln + outputJSON.Summary.WizCLISecretsSummary.LowVuln + outputJSON.Summary.WizCLIIacSastSummary.LowVuln + outputJSON.Summary.WizCLIVulnsSummary.LowVuln + outputJSON.Summary.SpotBugsSummary.LowVuln + outputJSON.Summary.TFSecSummary.LowVuln + outputJSON.Summary.SecurityCodeScanSummary.LowVuln
 
-	totalMedium = outputJSON.Summary.BrakemanSummary.MediumVuln + outputJSON.Summary.SafetySummary.MediumVuln + outputJSON.Summary.BanditSummary.MediumVuln + outputJSON.Summary.GosecSummary.MediumVuln + outputJSON.Summary.NpmAuditSummary.MediumVuln + outputJSON.Summary.YarnAuditSummary.MediumVuln + outputJSON.Summary.GitleaksSummary.MediumVuln + outputJSON.Summary.WizCLISummary.MediumVuln + outputJSON.Summary.SpotBugsSummary.MediumVuln + outputJSON.Summary.TFSecSummary.MediumVuln + outputJSON.Summary.SecurityCodeScanSummary.MediumVuln
+	totalMedium = outputJSON.Summary.BrakemanSummary.MediumVuln + outputJSON.Summary.SafetySummary.MediumVuln + outputJSON.Summary.BanditSummary.MediumVuln + outputJSON.Summary.GosecSummary.MediumVuln + outputJSON.Summary.NpmAuditSummary.MediumVuln + outputJSON.Summary.YarnAuditSummary.MediumVuln + outputJSON.Summary.GitleaksSummary.MediumVuln + outputJSON.Summary.WizCLISecretsSummary.MediumVuln + outputJSON.Summary.WizCLIIacSastSummary.MediumVuln + outputJSON.Summary.WizCLIVulnsSummary.MediumVuln + outputJSON.Summary.SpotBugsSummary.MediumVuln + outputJSON.Summary.TFSecSummary.MediumVuln + outputJSON.Summary.SecurityCodeScanSummary.MediumVuln
 
-	totalHigh = outputJSON.Summary.BrakemanSummary.HighVuln + outputJSON.Summary.SafetySummary.HighVuln + outputJSON.Summary.BanditSummary.HighVuln + outputJSON.Summary.GosecSummary.HighVuln + outputJSON.Summary.NpmAuditSummary.HighVuln + outputJSON.Summary.YarnAuditSummary.HighVuln + outputJSON.Summary.GitleaksSummary.HighVuln + outputJSON.Summary.WizCLISummary.HighVuln + outputJSON.Summary.SpotBugsSummary.HighVuln + outputJSON.Summary.TFSecSummary.HighVuln + outputJSON.Summary.SecurityCodeScanSummary.HighVuln
+	totalHigh = outputJSON.Summary.BrakemanSummary.HighVuln + outputJSON.Summary.SafetySummary.HighVuln + outputJSON.Summary.BanditSummary.HighVuln + outputJSON.Summary.GosecSummary.HighVuln + outputJSON.Summary.NpmAuditSummary.HighVuln + outputJSON.Summary.YarnAuditSummary.HighVuln + outputJSON.Summary.GitleaksSummary.HighVuln + outputJSON.Summary.WizCLISecretsSummary.HighVuln + outputJSON.Summary.WizCLIIacSastSummary.HighVuln + outputJSON.Summary.WizCLIVulnsSummary.HighVuln + outputJSON.Summary.SpotBugsSummary.HighVuln + outputJSON.Summary.TFSecSummary.HighVuln + outputJSON.Summary.SecurityCodeScanSummary.HighVuln
 
 	outputJSON.Summary.TotalSummary.HighVuln = totalHigh
 	outputJSON.Summary.TotalSummary.MediumVuln = totalMedium
@@ -263,7 +289,7 @@ func printAllSummary(analysis types.Analysis) {
 			spotbugsVersion = fmt.Sprintf("%s:%s", container.SecurityTest.Image, container.SecurityTest.ImageTag)
 		case "gitleaks":
 			gitleaksVersion = fmt.Sprintf("%s:%s", container.SecurityTest.Image, container.SecurityTest.ImageTag)
-		case "wizcli":
+		case "wizcli_secrets", "wizcli_iac_sast", "wizcli_vulns":
 			wizcliVersion = fmt.Sprintf("%s:%s", container.SecurityTest.Image, container.SecurityTest.ImageTag)
 		case "tfsec":
 			tfsecVersion = fmt.Sprintf("%s:%s", container.SecurityTest.Image, container.SecurityTest.ImageTag)
@@ -362,13 +388,31 @@ func printAllSummary(analysis types.Analysis) {
 		fmt.Printf("[HUSKYCI][SUMMARY] NoSecHusky: %d\n", outputJSON.Summary.GitleaksSummary.NoSecVuln)
 	}
 
-	if outputJSON.Summary.WizCLISummary.FoundVuln || outputJSON.Summary.WizCLISummary.FoundInfo {
+	if outputJSON.Summary.WizCLISecretsSummary.FoundVuln || outputJSON.Summary.WizCLISecretsSummary.FoundInfo {
 		fmt.Println()
 		fmt.Printf("[HUSKYCI][SUMMARY] Generic -> %s\n", wizcliVersion)
-		fmt.Printf("[HUSKYCI][SUMMARY] High: %d\n", outputJSON.Summary.WizCLISummary.HighVuln)
-		fmt.Printf("[HUSKYCI][SUMMARY] Medium: %d\n", outputJSON.Summary.WizCLISummary.MediumVuln)
-		fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", outputJSON.Summary.WizCLISummary.LowVuln)
-		fmt.Printf("[HUSKYCI][SUMMARY] NoSecHusky: %d\n", outputJSON.Summary.WizCLISummary.NoSecVuln)
+		fmt.Printf("[HUSKYCI][SUMMARY] Wiz CLI (Secrets) High: %d\n", outputJSON.Summary.WizCLISecretsSummary.HighVuln)
+		fmt.Printf("[HUSKYCI][SUMMARY] Wiz CLI (Secrets) Medium: %d\n", outputJSON.Summary.WizCLISecretsSummary.MediumVuln)
+		fmt.Printf("[HUSKYCI][SUMMARY] Wiz CLI (Secrets) Low: %d\n", outputJSON.Summary.WizCLISecretsSummary.LowVuln)
+		fmt.Printf("[HUSKYCI][SUMMARY] Wiz CLI (Secrets) NoSecHusky: %d\n", outputJSON.Summary.WizCLISecretsSummary.NoSecVuln)
+	}
+
+	if outputJSON.Summary.WizCLIIacSastSummary.FoundVuln || outputJSON.Summary.WizCLIIacSastSummary.FoundInfo {
+		fmt.Println()
+		fmt.Printf("[HUSKYCI][SUMMARY] Generic -> %s\n", wizcliVersion)
+		fmt.Printf("[HUSKYCI][SUMMARY] Wiz CLI (IaC+SAST) High: %d\n", outputJSON.Summary.WizCLIIacSastSummary.HighVuln)
+		fmt.Printf("[HUSKYCI][SUMMARY] Wiz CLI (IaC+SAST) Medium: %d\n", outputJSON.Summary.WizCLIIacSastSummary.MediumVuln)
+		fmt.Printf("[HUSKYCI][SUMMARY] Wiz CLI (IaC+SAST) Low: %d\n", outputJSON.Summary.WizCLIIacSastSummary.LowVuln)
+		fmt.Printf("[HUSKYCI][SUMMARY] Wiz CLI (IaC+SAST) NoSecHusky: %d\n", outputJSON.Summary.WizCLIIacSastSummary.NoSecVuln)
+	}
+
+	if outputJSON.Summary.WizCLIVulnsSummary.FoundVuln || outputJSON.Summary.WizCLIVulnsSummary.FoundInfo {
+		fmt.Println()
+		fmt.Printf("[HUSKYCI][SUMMARY] Generic -> %s\n", wizcliVersion)
+		fmt.Printf("[HUSKYCI][SUMMARY] Wiz CLI (Vulns) High: %d\n", outputJSON.Summary.WizCLIVulnsSummary.HighVuln)
+		fmt.Printf("[HUSKYCI][SUMMARY] Wiz CLI (Vulns) Medium: %d\n", outputJSON.Summary.WizCLIVulnsSummary.MediumVuln)
+		fmt.Printf("[HUSKYCI][SUMMARY] Wiz CLI (Vulns) Low: %d\n", outputJSON.Summary.WizCLIVulnsSummary.LowVuln)
+		fmt.Printf("[HUSKYCI][SUMMARY] Wiz CLI (Vulns) NoSecHusky: %d\n", outputJSON.Summary.WizCLIVulnsSummary.NoSecVuln)
 	}
 
 	if outputJSON.Summary.TotalSummary.FoundVuln || outputJSON.Summary.TotalSummary.FoundInfo {

--- a/client/analysis/output.go
+++ b/client/analysis/output.go
@@ -267,6 +267,19 @@ func prepareAllSummary(analysis types.Analysis) {
 
 }
 
+// shortImageName strips ECR registry prefix, returning only repo name.
+// "939030204144.dkr.ecr.us-east-1.amazonaws.com/huskyci-wiz" → "huskyci-wiz"
+// "huskyci/safety" (already short) → "huskyci/safety"
+func shortImageName(image string) string {
+	if idx := strings.LastIndex(image, "/"); idx != -1 {
+		// Check if "/" is part of an ECR domain (contains ".dkr." or ".amazonaws.com")
+		if strings.Contains(image[:idx], ".dkr.") || strings.Contains(image[:idx], ".amazonaws.com") {
+			return image[idx+1:]
+		}
+	}
+	return image
+}
+
 func printAllSummary(analysis types.Analysis) {
 
 	var gosecVersion, banditVersion, safetyVersion, brakemanVersion, npmauditVersion, yarnauditVersion, gitleaksVersion, wizcliSecretsVersion, wizcliIacSastVersion, wizcliVulnsVersion, spotbugsVersion, tfsecVersion, securityCodeScanVersion string
@@ -274,31 +287,31 @@ func printAllSummary(analysis types.Analysis) {
 	for _, container := range analysis.Containers {
 		switch container.SecurityTest.Name {
 		case "gosec":
-			gosecVersion = fmt.Sprintf("%s:%s", container.SecurityTest.Image, container.SecurityTest.ImageTag)
+			gosecVersion = fmt.Sprintf("%s:%s", shortImageName(container.SecurityTest.Image), container.SecurityTest.ImageTag)
 		case "bandit":
-			banditVersion = fmt.Sprintf("%s:%s", container.SecurityTest.Image, container.SecurityTest.ImageTag)
+			banditVersion = fmt.Sprintf("%s:%s", shortImageName(container.SecurityTest.Image), container.SecurityTest.ImageTag)
 		case "safety":
-			safetyVersion = fmt.Sprintf("%s:%s", container.SecurityTest.Image, container.SecurityTest.ImageTag)
+			safetyVersion = fmt.Sprintf("%s:%s", shortImageName(container.SecurityTest.Image), container.SecurityTest.ImageTag)
 		case "brakeman":
-			brakemanVersion = fmt.Sprintf("%s:%s", container.SecurityTest.Image, container.SecurityTest.ImageTag)
+			brakemanVersion = fmt.Sprintf("%s:%s", shortImageName(container.SecurityTest.Image), container.SecurityTest.ImageTag)
 		case "npmaudit":
-			npmauditVersion = fmt.Sprintf("%s:%s", container.SecurityTest.Image, container.SecurityTest.ImageTag)
+			npmauditVersion = fmt.Sprintf("%s:%s", shortImageName(container.SecurityTest.Image), container.SecurityTest.ImageTag)
 		case "yarnaudit":
-			yarnauditVersion = fmt.Sprintf("%s:%s", container.SecurityTest.Image, container.SecurityTest.ImageTag)
+			yarnauditVersion = fmt.Sprintf("%s:%s", shortImageName(container.SecurityTest.Image), container.SecurityTest.ImageTag)
 		case "spotbugs":
-			spotbugsVersion = fmt.Sprintf("%s:%s", container.SecurityTest.Image, container.SecurityTest.ImageTag)
+			spotbugsVersion = fmt.Sprintf("%s:%s", shortImageName(container.SecurityTest.Image), container.SecurityTest.ImageTag)
 		case "gitleaks":
-			gitleaksVersion = fmt.Sprintf("%s:%s", container.SecurityTest.Image, container.SecurityTest.ImageTag)
+			gitleaksVersion = fmt.Sprintf("%s:%s", shortImageName(container.SecurityTest.Image), container.SecurityTest.ImageTag)
 		case "wizcli_secrets":
-			wizcliSecretsVersion = fmt.Sprintf("%s:%s", container.SecurityTest.Image, container.SecurityTest.ImageTag)
+			wizcliSecretsVersion = fmt.Sprintf("%s:%s", shortImageName(container.SecurityTest.Image), container.SecurityTest.ImageTag)
 		case "wizcli_iac_sast":
-			wizcliIacSastVersion = fmt.Sprintf("%s:%s", container.SecurityTest.Image, container.SecurityTest.ImageTag)
+			wizcliIacSastVersion = fmt.Sprintf("%s:%s", shortImageName(container.SecurityTest.Image), container.SecurityTest.ImageTag)
 		case "wizcli_vulns":
-			wizcliVulnsVersion = fmt.Sprintf("%s:%s", container.SecurityTest.Image, container.SecurityTest.ImageTag)
+			wizcliVulnsVersion = fmt.Sprintf("%s:%s", shortImageName(container.SecurityTest.Image), container.SecurityTest.ImageTag)
 		case "tfsec":
-			tfsecVersion = fmt.Sprintf("%s:%s", container.SecurityTest.Image, container.SecurityTest.ImageTag)
+			tfsecVersion = fmt.Sprintf("%s:%s", shortImageName(container.SecurityTest.Image), container.SecurityTest.ImageTag)
 		case "securitycodescan":
-			securityCodeScanVersion = fmt.Sprintf("%s:%s", container.SecurityTest.Image, container.SecurityTest.ImageTag)
+			securityCodeScanVersion = fmt.Sprintf("%s:%s", shortImageName(container.SecurityTest.Image), container.SecurityTest.ImageTag)
 		}
 	}
 

--- a/client/analysis/output_wiz_test.go
+++ b/client/analysis/output_wiz_test.go
@@ -60,6 +60,25 @@ func testAgentDebugLog(t *testing.T, hypothesisID, message string, data map[stri
 
 // #endregion
 
+func TestShortImageName(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"939030204144.dkr.ecr.us-east-1.amazonaws.com/huskyci-wiz", "huskyci-wiz"},
+		{"939030204144.dkr.ecr.us-east-1.amazonaws.com/huskyci-gitleaks", "huskyci-gitleaks"},
+		{"huskyci/safety", "huskyci/safety"},
+		{"gosec", "gosec"},
+		{"123456789012.dkr.ecr.eu-west-1.amazonaws.com/my-tool", "my-tool"},
+	}
+	for _, tc := range tests {
+		got := shortImageName(tc.input)
+		if got != tc.expected {
+			t.Errorf("shortImageName(%q) = %q, want %q", tc.input, got, tc.expected)
+		}
+	}
+}
+
 func TestPrintSTDOUTOutput_IncludesWizCLIDetailsGroup(t *testing.T) {
 	types.FoundVuln = false
 	types.FoundInfo = false
@@ -68,7 +87,7 @@ func TestPrintSTDOUTOutput_IncludesWizCLIDetailsGroup(t *testing.T) {
 	analysis := types.Analysis{
 		Containers: []types.Container{
 			{
-				SecurityTest: types.SecurityTest{Name: "wizcli_secrets", Image: "ecr/huskyci-wiz", ImageTag: "latest-amd64"},
+				SecurityTest: types.SecurityTest{Name: "wizcli_secrets", Image: "939030204144.dkr.ecr.us-east-1.amazonaws.com/huskyci-wiz", ImageTag: "f793155-amd64"},
 			},
 		},
 		HuskyCIResults: types.HuskyCIResults{
@@ -144,8 +163,12 @@ func TestPrintSTDOUTOutput_IncludesWizCLIDetailsGroup(t *testing.T) {
 	if !bytes.Contains([]byte(out), []byte("::group::Generic - Wiz CLI (Vulns)")) {
 		t.Fatalf("expected Wiz CLI Vulns collapsible group in stdout, got excerpt:\n%s", truncate(out, 2000))
 	}
-	if !bytes.Contains([]byte(out), []byte("[HUSKYCI][SUMMARY] Generic ->")) || !bytes.Contains([]byte(out), []byte("huskyci-wiz")) {
-		t.Fatalf("expected Wiz summary line with image ref")
+	if !bytes.Contains([]byte(out), []byte("[HUSKYCI][SUMMARY] Generic -> huskyci-wiz:f793155-amd64")) {
+		t.Fatalf("expected Wiz summary line with short image ref 'huskyci-wiz:f793155-amd64', got excerpt:\n%s", truncate(out, 2000))
+	}
+	// Verify ECR registry prefix is NOT present in output
+	if bytes.Contains([]byte(out), []byte("939030204144.dkr.ecr.us-east-1.amazonaws.com")) {
+		t.Fatalf("ECR registry prefix should be stripped from version string, got excerpt:\n%s", truncate(out, 2000))
 	}
 	if !bytes.Contains([]byte(out), []byte("CVE-2024-0001")) {
 		t.Fatalf("expected Wiz finding title in stdout")

--- a/client/analysis/output_wiz_test.go
+++ b/client/analysis/output_wiz_test.go
@@ -68,12 +68,17 @@ func TestPrintSTDOUTOutput_IncludesWizCLIDetailsGroup(t *testing.T) {
 	analysis := types.Analysis{
 		Containers: []types.Container{
 			{
-				SecurityTest: types.SecurityTest{Name: "wizcli", Image: "ecr/huskyci-wiz", ImageTag: "latest-amd64"},
+				SecurityTest: types.SecurityTest{Name: "wizcli_secrets", Image: "ecr/huskyci-wiz", ImageTag: "latest-amd64"},
 			},
 		},
 		HuskyCIResults: types.HuskyCIResults{
 			GenericResults: types.GenericResults{
-				HuskyCIWizCLIOutput: types.HuskyCISecurityTestOutput{
+				HuskyCIWizCLISecretsOutput: types.HuskyCISecurityTestOutput{
+					MediumVulns: []types.HuskyCIVulnerability{
+						{Title: "Secret in env", SecurityTool: "WizCLI", Severity: "MEDIUM", Details: "mock", File: "x.env"},
+					},
+				},
+				HuskyCIWizCLIVulnsOutput: types.HuskyCISecurityTestOutput{
 					HighVulns: []types.HuskyCIVulnerability{
 						{
 							Title:        "CVE-2024-0001 in library foo",
@@ -86,18 +91,17 @@ func TestPrintSTDOUTOutput_IncludesWizCLIDetailsGroup(t *testing.T) {
 							Code:         "foo@1.0.0",
 						},
 					},
-					MediumVulns: []types.HuskyCIVulnerability{
-						{Title: "Secret in env", SecurityTool: "WizCLI", Severity: "MEDIUM", Details: "mock", File: "x.env"},
-					},
 				},
 			},
 		},
 	}
 
 	// #region agent log
-	wiz := analysis.HuskyCIResults.GenericResults.HuskyCIWizCLIOutput
+	secrets := analysis.HuskyCIResults.GenericResults.HuskyCIWizCLISecretsOutput
+	vulns := analysis.HuskyCIResults.GenericResults.HuskyCIWizCLIVulnsOutput
 	testAgentDebugLog(t, "H1", "fixture wiz counts", map[string]any{
-		"high": len(wiz.HighVulns), "medium": len(wiz.MediumVulns), "low": len(wiz.LowVulns),
+		"secrets_high": len(secrets.HighVulns), "secrets_medium": len(secrets.MediumVulns),
+		"vulns_high": len(vulns.HighVulns), "vulns_medium": len(vulns.MediumVulns),
 	})
 	// #endregion
 
@@ -106,8 +110,11 @@ func TestPrintSTDOUTOutput_IncludesWizCLIDetailsGroup(t *testing.T) {
 		printSTDOUTOutput(analysis)
 	})
 
-	if !bytes.Contains([]byte(out), []byte("::group::Generic - Wiz CLI Details")) {
-		t.Fatalf("expected Wiz CLI collapsible group in stdout, got excerpt:\n%s", truncate(out, 2000))
+	if !bytes.Contains([]byte(out), []byte("::group::Generic - Wiz CLI (Secrets)")) {
+		t.Fatalf("expected Wiz CLI Secrets collapsible group in stdout, got excerpt:\n%s", truncate(out, 2000))
+	}
+	if !bytes.Contains([]byte(out), []byte("::group::Generic - Wiz CLI (Vulns)")) {
+		t.Fatalf("expected Wiz CLI Vulns collapsible group in stdout, got excerpt:\n%s", truncate(out, 2000))
 	}
 	if !bytes.Contains([]byte(out), []byte("[HUSKYCI][SUMMARY] Generic ->")) || !bytes.Contains([]byte(out), []byte("huskyci-wiz")) {
 		t.Fatalf("expected Wiz summary line with image ref")

--- a/client/analysis/output_wiz_test.go
+++ b/client/analysis/output_wiz_test.go
@@ -78,6 +78,31 @@ func TestPrintSTDOUTOutput_IncludesWizCLIDetailsGroup(t *testing.T) {
 						{Title: "Secret in env", SecurityTool: "WizCLI", Severity: "MEDIUM", Details: "mock", File: "x.env"},
 					},
 				},
+				HuskyCIIacSastOutput: types.HuskyCISecurityTestOutput{
+					HighVulns: []types.HuskyCIVulnerability{
+						{
+							Title:        "S3 bucket without encryption",
+							Language:     "HCL",
+							SecurityTool: "WizCLI",
+							Severity:     "HIGH",
+							Details:      "Enable server-side encryption",
+							File:         "main.tf",
+							Line:         "15",
+							Code:         "aws_s3_bucket.example",
+						},
+					},
+					LowVulns: []types.HuskyCIVulnerability{
+						{
+							Title:        "Missing tags on resource",
+							Language:     "HCL",
+							SecurityTool: "WizCLI",
+							Severity:     "LOW",
+							Details:      "Add tags for cost tracking",
+							File:         "main.tf",
+							Line:         "22",
+						},
+					},
+				},
 				HuskyCIWizCLIVulnsOutput: types.HuskyCISecurityTestOutput{
 					HighVulns: []types.HuskyCIVulnerability{
 						{
@@ -113,6 +138,9 @@ func TestPrintSTDOUTOutput_IncludesWizCLIDetailsGroup(t *testing.T) {
 	if !bytes.Contains([]byte(out), []byte("::group::Generic - Wiz CLI (Secrets)")) {
 		t.Fatalf("expected Wiz CLI Secrets collapsible group in stdout, got excerpt:\n%s", truncate(out, 2000))
 	}
+	if !bytes.Contains([]byte(out), []byte("::group::Generic - Wiz CLI (IaC+SAST)")) {
+		t.Fatalf("expected Wiz CLI IaC+SAST collapsible group in stdout, got excerpt:\n%s", truncate(out, 2000))
+	}
 	if !bytes.Contains([]byte(out), []byte("::group::Generic - Wiz CLI (Vulns)")) {
 		t.Fatalf("expected Wiz CLI Vulns collapsible group in stdout, got excerpt:\n%s", truncate(out, 2000))
 	}
@@ -121,6 +149,12 @@ func TestPrintSTDOUTOutput_IncludesWizCLIDetailsGroup(t *testing.T) {
 	}
 	if !bytes.Contains([]byte(out), []byte("CVE-2024-0001")) {
 		t.Fatalf("expected Wiz finding title in stdout")
+	}
+	if !bytes.Contains([]byte(out), []byte("S3 bucket without encryption")) {
+		t.Fatalf("expected IaC+SAST finding title in stdout")
+	}
+	if !bytes.Contains([]byte(out), []byte("Missing tags on resource")) {
+		t.Fatalf("expected IaC+SAST low finding title in stdout")
 	}
 }
 

--- a/client/integration/sonarqube/sonarqube.go
+++ b/client/integration/sonarqube/sonarqube.go
@@ -60,9 +60,15 @@ func GenerateOutputFile(analysis types.Analysis, outputPath, outputFileName stri
 	allVulns = append(allVulns, analysis.HuskyCIResults.GenericResults.HuskyCIGitleaksOutput.HighVulns...)
 
 	// wizcli
-	allVulns = append(allVulns, analysis.HuskyCIResults.GenericResults.HuskyCIWizCLIOutput.LowVulns...)
-	allVulns = append(allVulns, analysis.HuskyCIResults.GenericResults.HuskyCIWizCLIOutput.MediumVulns...)
-	allVulns = append(allVulns, analysis.HuskyCIResults.GenericResults.HuskyCIWizCLIOutput.HighVulns...)
+	allVulns = append(allVulns, analysis.HuskyCIResults.GenericResults.HuskyCIWizCLISecretsOutput.LowVulns...)
+	allVulns = append(allVulns, analysis.HuskyCIResults.GenericResults.HuskyCIWizCLISecretsOutput.MediumVulns...)
+	allVulns = append(allVulns, analysis.HuskyCIResults.GenericResults.HuskyCIWizCLISecretsOutput.HighVulns...)
+	allVulns = append(allVulns, analysis.HuskyCIResults.GenericResults.HuskyCIIacSastOutput.LowVulns...)
+	allVulns = append(allVulns, analysis.HuskyCIResults.GenericResults.HuskyCIIacSastOutput.MediumVulns...)
+	allVulns = append(allVulns, analysis.HuskyCIResults.GenericResults.HuskyCIIacSastOutput.HighVulns...)
+	allVulns = append(allVulns, analysis.HuskyCIResults.GenericResults.HuskyCIWizCLIVulnsOutput.LowVulns...)
+	allVulns = append(allVulns, analysis.HuskyCIResults.GenericResults.HuskyCIWizCLIVulnsOutput.MediumVulns...)
+	allVulns = append(allVulns, analysis.HuskyCIResults.GenericResults.HuskyCIWizCLIVulnsOutput.HighVulns...)
 
 	// spotbugs
 	allVulns = append(allVulns, analysis.HuskyCIResults.JavaResults.HuskyCISpotBugsOutput.LowVulns...)

--- a/client/integration/sonarqube/sonarqube_wizcli_test.go
+++ b/client/integration/sonarqube/sonarqube_wizcli_test.go
@@ -12,11 +12,11 @@ import (
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
-func makeWizAnalysis(high, medium, low []types.HuskyCIVulnerability) types.Analysis {
+func makeWizSecretsAnalysis(high, medium, low []types.HuskyCIVulnerability) types.Analysis {
 	return types.Analysis{
 		HuskyCIResults: types.HuskyCIResults{
 			GenericResults: types.GenericResults{
-				HuskyCIWizCLIOutput: types.HuskyCISecurityTestOutput{
+				HuskyCIWizCLISecretsOutput: types.HuskyCISecurityTestOutput{
 					HighVulns:   high,
 					MediumVulns: medium,
 					LowVulns:    low,
@@ -66,7 +66,7 @@ func TestGenerateOutputFile_WizCLI_HighVuln(t *testing.T) {
 	outputFileName := "sonarqube.json"
 
 	vuln := makeWizVuln("AWS Access Key", "HIGH", "./code/config/settings.py")
-	analysis := makeWizAnalysis([]types.HuskyCIVulnerability{vuln}, nil, nil)
+	analysis := makeWizSecretsAnalysis([]types.HuskyCIVulnerability{vuln}, nil, nil)
 
 	if err := GenerateOutputFile(analysis, outputPath+"/", outputFileName); err != nil {
 		t.Fatalf("GenerateOutputFile returned error: %v", err)
@@ -93,7 +93,7 @@ func TestGenerateOutputFile_WizCLI_MediumVuln(t *testing.T) {
 	outputFileName := "sonarqube.json"
 
 	vuln := makeWizVuln("Generic API Key", "MEDIUM", "./code/src/client.go")
-	analysis := makeWizAnalysis(nil, []types.HuskyCIVulnerability{vuln}, nil)
+	analysis := makeWizSecretsAnalysis(nil, []types.HuskyCIVulnerability{vuln}, nil)
 
 	if err := GenerateOutputFile(analysis, outputPath+"/", outputFileName); err != nil {
 		t.Fatalf("GenerateOutputFile returned error: %v", err)
@@ -131,7 +131,7 @@ func TestGenerateOutputFile_WizCLI_LowVuln(t *testing.T) {
 	outputFileName := "sonarqube.json"
 
 	vuln := makeWizVuln("Email Address", "LOW", "./code/data/users.csv")
-	analysis := makeWizAnalysis(nil, nil, []types.HuskyCIVulnerability{vuln})
+	analysis := makeWizSecretsAnalysis(nil, nil, []types.HuskyCIVulnerability{vuln})
 
 	if err := GenerateOutputFile(analysis, outputPath+"/", outputFileName); err != nil {
 		t.Fatalf("GenerateOutputFile returned error: %v", err)
@@ -168,7 +168,7 @@ func TestGenerateOutputFile_WizCLI_NoVulns(t *testing.T) {
 	outputPath := t.TempDir()
 	outputFileName := "sonarqube.json"
 
-	analysis := makeWizAnalysis(nil, nil, nil)
+	analysis := makeWizSecretsAnalysis(nil, nil, nil)
 
 	if err := GenerateOutputFile(analysis, outputPath+"/", outputFileName); err != nil {
 		t.Fatalf("GenerateOutputFile returned error: %v", err)
@@ -205,7 +205,7 @@ func TestGenerateOutputFile_WizCLI_AllSeverities(t *testing.T) {
 	medVuln := makeWizVuln("Generic API Key", "MEDIUM", "./code/src/client.go")
 	lowVuln := makeWizVuln("Email Address", "LOW", "./code/data/users.csv")
 
-	analysis := makeWizAnalysis(
+	analysis := makeWizSecretsAnalysis(
 		[]types.HuskyCIVulnerability{highVuln},
 		[]types.HuskyCIVulnerability{medVuln},
 		[]types.HuskyCIVulnerability{lowVuln},

--- a/client/integration/sonarqube/sonarqube_wizcli_test.go
+++ b/client/integration/sonarqube/sonarqube_wizcli_test.go
@@ -26,6 +26,34 @@ func makeWizSecretsAnalysis(high, medium, low []types.HuskyCIVulnerability) type
 	}
 }
 
+func makeWizIacSastAnalysis(high, medium, low []types.HuskyCIVulnerability) types.Analysis {
+	return types.Analysis{
+		HuskyCIResults: types.HuskyCIResults{
+			GenericResults: types.GenericResults{
+				HuskyCIIacSastOutput: types.HuskyCISecurityTestOutput{
+					HighVulns:   high,
+					MediumVulns: medium,
+					LowVulns:    low,
+				},
+			},
+		},
+	}
+}
+
+func makeWizVulnsAnalysis(high, medium, low []types.HuskyCIVulnerability) types.Analysis {
+	return types.Analysis{
+		HuskyCIResults: types.HuskyCIResults{
+			GenericResults: types.GenericResults{
+				HuskyCIWizCLIVulnsOutput: types.HuskyCISecurityTestOutput{
+					HighVulns:   high,
+					MediumVulns: medium,
+					LowVulns:    low,
+				},
+			},
+		},
+	}
+}
+
 func makeWizVuln(title, severity, file string) types.HuskyCIVulnerability {
 	return types.HuskyCIVulnerability{
 		Language:     "Generic",
@@ -225,6 +253,170 @@ func TestGenerateOutputFile_WizCLI_AllSeverities(t *testing.T) {
 		"CVE-2021-23337": "BLOCKER",
 		"Generic API Key": "MAJOR",
 		"Email Address":  "MINOR",
+	}
+
+	for title, expectedRuleSev := range severityMap {
+		issue := findIssueByTitle(out, title)
+		if issue == nil {
+			t.Errorf("expected issue for %q not found", title)
+			continue
+		}
+		var rule *SonarRule
+		for i := range out.Rules {
+			if out.Rules[i].ID == issue.RuleID {
+				rule = &out.Rules[i]
+				break
+			}
+		}
+		if rule == nil {
+			t.Errorf("no rule found for issue %q (ruleId=%s)", title, issue.RuleID)
+			continue
+		}
+		if rule.Severity != expectedRuleSev {
+			t.Errorf("issue %q: expected rule severity %s, got %s", title, expectedRuleSev, rule.Severity)
+		}
+	}
+}
+
+// ── TestGenerateOutputFile_WizCLI_IacSast_HighVuln ─────────────────────────────
+
+func TestGenerateOutputFile_WizCLI_IacSast_HighVuln(t *testing.T) {
+	outputPath := t.TempDir()
+	outputFileName := "sonarqube.json"
+
+	vuln := makeWizVuln("S3 bucket without encryption", "HIGH", "./infra/main.tf")
+	analysis := makeWizIacSastAnalysis([]types.HuskyCIVulnerability{vuln}, nil, nil)
+
+	if err := GenerateOutputFile(analysis, outputPath+"/", outputFileName); err != nil {
+		t.Fatalf("GenerateOutputFile returned error: %v", err)
+	}
+
+	out := readSonarOutput(t, outputPath, outputFileName)
+
+	if len(out.Issues) == 0 {
+		t.Fatal("expected at least one issue in sonar output, got none")
+	}
+	issue := findIssueByTitle(out, "S3 bucket without encryption")
+	if issue == nil {
+		t.Fatalf("expected issue for 'S3 bucket without encryption', not found in: %+v", out.Issues)
+	}
+	if issue.RuleID == "" {
+		t.Error("expected non-empty ruleId")
+	}
+}
+
+// ── TestGenerateOutputFile_WizCLI_IacSast_AllSeverities ────────────────────────
+
+func TestGenerateOutputFile_WizCLI_IacSast_AllSeverities(t *testing.T) {
+	outputPath := t.TempDir()
+	outputFileName := "sonarqube.json"
+
+	highVuln := makeWizVuln("S3 bucket without encryption", "HIGH", "./infra/main.tf")
+	medVuln := makeWizVuln("IAM policy too permissive", "MEDIUM", "./infra/iam.tf")
+	lowVuln := makeWizVuln("Missing tags on resource", "LOW", "./infra/tags.tf")
+
+	analysis := makeWizIacSastAnalysis(
+		[]types.HuskyCIVulnerability{highVuln},
+		[]types.HuskyCIVulnerability{medVuln},
+		[]types.HuskyCIVulnerability{lowVuln},
+	)
+
+	if err := GenerateOutputFile(analysis, outputPath+"/", outputFileName); err != nil {
+		t.Fatalf("GenerateOutputFile returned error: %v", err)
+	}
+
+	out := readSonarOutput(t, outputPath, outputFileName)
+
+	if len(out.Issues) < 3 {
+		t.Errorf("expected at least 3 issues (one per severity), got %d", len(out.Issues))
+	}
+
+	severityMap := map[string]string{
+		"S3 bucket without encryption":  "BLOCKER",
+		"IAM policy too permissive":      "MAJOR",
+		"Missing tags on resource":       "MINOR",
+	}
+
+	for title, expectedRuleSev := range severityMap {
+		issue := findIssueByTitle(out, title)
+		if issue == nil {
+			t.Errorf("expected issue for %q not found", title)
+			continue
+		}
+		var rule *SonarRule
+		for i := range out.Rules {
+			if out.Rules[i].ID == issue.RuleID {
+				rule = &out.Rules[i]
+				break
+			}
+		}
+		if rule == nil {
+			t.Errorf("no rule found for issue %q (ruleId=%s)", title, issue.RuleID)
+			continue
+		}
+		if rule.Severity != expectedRuleSev {
+			t.Errorf("issue %q: expected rule severity %s, got %s", title, expectedRuleSev, rule.Severity)
+		}
+	}
+}
+
+// ── TestGenerateOutputFile_WizCLI_Vulns_HighVuln ──────────────────────────────
+
+func TestGenerateOutputFile_WizCLI_Vulns_HighVuln(t *testing.T) {
+	outputPath := t.TempDir()
+	outputFileName := "sonarqube.json"
+
+	vuln := makeWizVuln("CVE-2024-0001 in library foo", "HIGH", "./code/package-lock.json")
+	analysis := makeWizVulnsAnalysis([]types.HuskyCIVulnerability{vuln}, nil, nil)
+
+	if err := GenerateOutputFile(analysis, outputPath+"/", outputFileName); err != nil {
+		t.Fatalf("GenerateOutputFile returned error: %v", err)
+	}
+
+	out := readSonarOutput(t, outputPath, outputFileName)
+
+	if len(out.Issues) == 0 {
+		t.Fatal("expected at least one issue in sonar output, got none")
+	}
+	issue := findIssueByTitle(out, "CVE-2024-0001")
+	if issue == nil {
+		t.Fatalf("expected issue for 'CVE-2024-0001', not found in: %+v", out.Issues)
+	}
+	if issue.RuleID == "" {
+		t.Error("expected non-empty ruleId")
+	}
+}
+
+// ── TestGenerateOutputFile_WizCLI_Vulns_AllSeverities ──────────────────────────
+
+func TestGenerateOutputFile_WizCLI_Vulns_AllSeverities(t *testing.T) {
+	outputPath := t.TempDir()
+	outputFileName := "sonarqube.json"
+
+	highVuln := makeWizVuln("CVE-2024-0001 in library foo", "HIGH", "./code/package-lock.json")
+	medVuln := makeWizVuln("CVE-2023-9999 in library bar", "MEDIUM", "./code/yarn.lock")
+	lowVuln := makeWizVuln("CVE-2022-5555 in library baz", "LOW", "./code/requirements.txt")
+
+	analysis := makeWizVulnsAnalysis(
+		[]types.HuskyCIVulnerability{highVuln},
+		[]types.HuskyCIVulnerability{medVuln},
+		[]types.HuskyCIVulnerability{lowVuln},
+	)
+
+	if err := GenerateOutputFile(analysis, outputPath+"/", outputFileName); err != nil {
+		t.Fatalf("GenerateOutputFile returned error: %v", err)
+	}
+
+	out := readSonarOutput(t, outputPath, outputFileName)
+
+	if len(out.Issues) < 3 {
+		t.Errorf("expected at least 3 issues (one per severity), got %d", len(out.Issues))
+	}
+
+	severityMap := map[string]string{
+		"CVE-2024-0001": "BLOCKER",
+		"CVE-2023-9999": "MAJOR",
+		"CVE-2022-5555": "MINOR",
 	}
 
 	for title, expectedRuleSev := range severityMap {

--- a/client/integration/sonarqube/testdata/analysis/wizcli_dependency_findings.json
+++ b/client/integration/sonarqube/testdata/analysis/wizcli_dependency_findings.json
@@ -2,7 +2,7 @@
   "containerID": "test-wizcli-dependency-scan",
   "huskyciresults": {
     "genericresults": {
-      "wizclioutput": {
+      "wizclivulnsoutput": {
         "lowvulns": [],
         "mediumvulns": [],
         "highvulns": [

--- a/client/types/types.go
+++ b/client/types/types.go
@@ -153,7 +153,7 @@ type RubyResults struct {
 type GenericResults struct {
 	HuskyCIGitleaksOutput      HuskyCISecurityTestOutput `bson:"gitleaksoutput,omitempty" json:"gitleaksoutput,omitempty"`
 	HuskyCIWizCLISecretsOutput HuskyCISecurityTestOutput `bson:"wizclisecretsoutput,omitempty" json:"wizclisecretsoutput,omitempty"`
-	HuskyCIIacSastOutput       HuskyCISecurityTestOutput `bson:"iavsastoutput,omitempty" json:"iavsastoutput,omitempty"`
+	HuskyCIIacSastOutput       HuskyCISecurityTestOutput `bson:"iacsastoutput,omitempty" json:"iacsastoutput,omitempty"`
 	HuskyCIWizCLIVulnsOutput   HuskyCISecurityTestOutput `bson:"wizclivulnsoutput,omitempty" json:"wizclivulnsoutput,omitempty"`
 }
 

--- a/client/types/types.go
+++ b/client/types/types.go
@@ -151,8 +151,10 @@ type RubyResults struct {
 
 // GenericResults represents all generic securityTests results.
 type GenericResults struct {
-	HuskyCIGitleaksOutput HuskyCISecurityTestOutput `bson:"gitleaksoutput,omitempty" json:"gitleaksoutput,omitempty"`
-	HuskyCIWizCLIOutput   HuskyCISecurityTestOutput `bson:"wizclioutput,omitempty" json:"wizclioutput,omitempty"`
+	HuskyCIGitleaksOutput      HuskyCISecurityTestOutput `bson:"gitleaksoutput,omitempty" json:"gitleaksoutput,omitempty"`
+	HuskyCIWizCLISecretsOutput HuskyCISecurityTestOutput `bson:"wizclisecretsoutput,omitempty" json:"wizclisecretsoutput,omitempty"`
+	HuskyCIIacSastOutput       HuskyCISecurityTestOutput `bson:"iavsastoutput,omitempty" json:"iavsastoutput,omitempty"`
+	HuskyCIWizCLIVulnsOutput   HuskyCISecurityTestOutput `bson:"wizclivulnsoutput,omitempty" json:"wizclivulnsoutput,omitempty"`
 }
 
 // HclResults represents all HCL security tests results.
@@ -186,7 +188,9 @@ type Summary struct {
 	BrakemanSummary         HuskyCISummary `json:"brakemansummary,omitempty"`
 	SpotBugsSummary         HuskyCISummary `json:"spotbugssummary,omitempty"`
 	GitleaksSummary         HuskyCISummary `json:"gitleakssummary,omitempty"`
-	WizCLISummary           HuskyCISummary `json:"wizclisummary,omitempty"`
+	WizCLISecretsSummary   HuskyCISummary `json:"wizclisecretssummary,omitempty"`
+	WizCLIIacSastSummary   HuskyCISummary `json:"wizcliiacsastsummary,omitempty"`
+	WizCLIVulnsSummary     HuskyCISummary `json:"wizclivulnssummary,omitempty"`
 	TFSecSummary            HuskyCISummary `json:"tfsecsummary,omitempty"`
 	SecurityCodeScanSummary HuskyCISummary `json:"securitycodescansummary,omitempty"`
 	TotalSummary            HuskyCISummary `json:"totalsummary,omitempty"`

--- a/docs/superpowers/plans/2026-05-22-errgroup-channel-race.md
+++ b/docs/superpowers/plans/2026-05-22-errgroup-channel-race.md
@@ -1,0 +1,480 @@
+# Fix 1: errgroup Channel Race — Implementation Plan (TDD)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Eliminate `panic: send on closed channel` by replacing manual errChan/syncChan/waitChan/wg with errgroup.
+
+**Architecture:** Introduce `scanRunner` interface to mock DB + K8s calls. Refactor Start, runGenericScans, runLanguageScans to use errgroup.WithContext. This plan does NOT add mutex — that's Fix 2.
+
+**Tech Stack:** Go 1.20, golang.org/x/sync v0.8.0
+
+---
+
+### Task 1: Create worktree + promote dependency
+
+- [ ] **Step 1: Create worktree**
+
+```bash
+cd ~/Gits/huskyci-api
+git worktree add ../huskyci-api-errgroup fix/errgroup-channel-race 2>/dev/null || {
+  git branch fix/errgroup-channel-race
+  git worktree add ../huskyci-api-errgroup fix/errgroup-channel-race
+}
+```
+
+- [ ] **Step 2: Promote dependency**
+
+```bash
+cd ~/Gits/huskyci-api-errgroup/api
+go get golang.org/x/sync@v0.8.0
+go mod tidy
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd ~/Gits/huskyci-api-errgroup
+git add api/go.mod api/go.sum
+git commit -m "chore: promote golang.org/x/sync to direct dependency for errgroup refactor"
+```
+
+---
+
+### Task 2: RED — Write failing tests for errgroup behavior
+
+- [ ] **Step 1: Create scanRunner interface**
+
+Create `api/securitytest/runner.go`:
+
+```go
+package securitytest
+
+import "github.com/githubanotaai/huskyci-api/api/types"
+
+// scanRunner abstracts scan lifecycle so tests can mock
+// DB queries and scan execution without MongoDB or K8s.
+type scanRunner interface {
+	listGenericTests() ([]types.SecurityTest, error)
+	listLanguageTests(language string) ([]types.SecurityTest, error)
+	newScan(RID, URL, branch, securityTestName string, languageExclusions map[string]bool, dockerHost string) (*SecTestScanInfo, error)
+	startScan(scan *SecTestScanInfo) error
+}
+
+// realRunner delegates to actual SecTestScanInfo + DB methods.
+type realRunner struct{}
+
+func (realRunner) listGenericTests() ([]types.SecurityTest, error) {
+	return getAllDefaultSecurityTests("Generic", "")
+}
+
+func (realRunner) listLanguageTests(language string) ([]types.SecurityTest, error) {
+	return getAllDefaultSecurityTests("Language", language)
+}
+
+func (realRunner) newScan(RID, URL, branch, securityTestName string, languageExclusions map[string]bool, dockerHost string) (*SecTestScanInfo, error) {
+	scan := &SecTestScanInfo{}
+	return scan, scan.New(RID, URL, branch, securityTestName, languageExclusions, dockerHost)
+}
+
+func (realRunner) startScan(scan *SecTestScanInfo) error {
+	return scan.Start()
+}
+
+// mockRunner returns preconfigured results for testing.
+type mockRunner struct {
+	genericTests   []types.SecurityTest
+	languageTests   []types.SecurityTest
+	newScanFunc    func(RID, URL, branch, securityTestName string, languageExclusions map[string]bool, dockerHost string) (*SecTestScanInfo, error)
+	startScanFunc  func(scan *SecTestScanInfo) error
+}
+
+func (m *mockRunner) listGenericTests() ([]types.SecurityTest, error) {
+	return m.genericTests, nil
+}
+
+func (m *mockRunner) listLanguageTests(language string) ([]types.SecurityTest, error) {
+	return m.languageTests, nil
+}
+
+func (m *mockRunner) newScan(RID, URL, branch, securityTestName string, languageExclusions map[string]bool, dockerHost string) (*SecTestScanInfo, error) {
+	if m.newScanFunc != nil {
+		return m.newScanFunc(RID, URL, branch, securityTestName, languageExclusions, dockerHost)
+	}
+	return &SecTestScanInfo{}, nil
+}
+
+func (m *mockRunner) startScan(scan *SecTestScanInfo) error {
+	if m.startScanFunc != nil {
+		return m.startScanFunc(scan)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 2: Add runner field to RunAllInfo (so tests can inject mocks)**
+
+In `api/securitytest/run.go`, add to imports: `"context"` and remove `"sync"`. Add to `RunAllInfo`:
+
+```go
+type RunAllInfo struct {
+	runner         scanRunner `json:"-" bson:"-"`
+	RID            string
+	// ... rest unchanged ...
+}
+```
+
+Add helper method:
+
+```go
+func (results *RunAllInfo) getRunner() scanRunner {
+	if results.runner != nil {
+		return results.runner
+	}
+	return realRunner{}
+}
+```
+
+- [ ] **Step 3: Write the failing tests**
+
+Add to `api/securitytest/run_test.go` — add `"fmt"`, `"sync/atomic"` to imports:
+
+```go
+func TestStart_FirstErrorCancelsRemaining(t *testing.T) {
+	// Bug 1: under old errChan/syncChan pattern, concurrent error sends
+	// cause panic. Under errgroup, first error returns cleanly.
+	mockGenericTests := []types.SecurityTest{
+		{Name: "gitleaks"},
+		{Name: "gitauthors"},
+	}
+
+	runner := &mockRunner{
+		genericTests: mockGenericTests,
+		newScanFunc: func(RID, URL, branch, name string, le map[string]bool, dh string) (*SecTestScanInfo, error) {
+			return &SecTestScanInfo{
+				RID:              RID,
+				SecurityTestName: name,
+				Container:        types.Container{CID: "cid-" + name, CResult: "passed"},
+			}, nil
+		},
+		startScanFunc: func(scan *SecTestScanInfo) error {
+			if scan.SecurityTestName == "gitleaks" {
+				return fmt.Errorf("gitleaks scan failed")
+			}
+			return nil
+		},
+	}
+
+	results := &RunAllInfo{runner: runner}
+	enryScan := SecTestScanInfo{
+		RID: "test-rid", URL: "https://example.com/repo", Branch: "main",
+	}
+
+	err := results.Start(enryScan)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if err.Error() != "gitleaks scan failed" {
+		t.Errorf("expected 'gitleaks scan failed', got %q", err.Error())
+	}
+}
+
+func TestStart_ConcurrentErrorsNoPanic(t *testing.T) {
+	// Stress test: all scans error simultaneously — no panic allowed.
+	mockGenericTests := []types.SecurityTest{
+		{Name: "gitleaks"}, {Name: "gitauthors"},
+	}
+
+	runner := &mockRunner{
+		genericTests: mockGenericTests,
+		newScanFunc: func(RID, URL, branch, name string, le map[string]bool, dh string) (*SecTestScanInfo, error) {
+			return &SecTestScanInfo{
+				RID: RID, SecurityTestName: name,
+				Container: types.Container{CID: "cid-" + name},
+			}, nil
+		},
+		startScanFunc: func(scan *SecTestScanInfo) error {
+			return fmt.Errorf("scan %s failed", scan.SecurityTestName)
+		},
+	}
+
+	results := &RunAllInfo{runner: runner}
+	enryScan := SecTestScanInfo{
+		RID: "test-rid-stress", URL: "https://example.com/repo", Branch: "main",
+	}
+
+	// The key assertion: no panic
+	err := results.Start(enryScan)
+	if err == nil {
+		t.Fatal("expected error with all scans failing")
+	}
+}
+
+func TestStart_AllScansPass(t *testing.T) {
+	mockGenericTests := []types.SecurityTest{
+		{Name: "gitleaks"}, {Name: "gitauthors"},
+	}
+
+	runner := &mockRunner{
+		genericTests: mockGenericTests,
+		newScanFunc: func(RID, URL, branch, name string, le map[string]bool, dh string) (*SecTestScanInfo, error) {
+			return &SecTestScanInfo{
+				RID: RID, SecurityTestName: name,
+				Container: types.Container{CID: "cid-" + name, CResult: "passed", CStatus: "finished"},
+			}, nil
+		},
+		startScanFunc: func(scan *SecTestScanInfo) error { return nil },
+	}
+
+	results := &RunAllInfo{runner: runner}
+	enryScan := SecTestScanInfo{
+		RID: "test-rid-pass", URL: "https://example.com/repo", Branch: "main",
+	}
+
+	err := results.Start(enryScan)
+	if err != nil {
+		t.Errorf("expected nil, got %v", err)
+	}
+}
+```
+
+- [ ] **Step 4: Run tests — verify they FAIL**
+
+```bash
+cd ~/Gits/huskyci-api-errgroup/api
+go test -v -run "TestStart_First|TestStart_Concurrent|TestStart_All" ./securitytest/ 2>&1 | tail -20
+```
+
+Expected: FAIL — Start() still uses old channel pattern, not errgroup.
+
+- [ ] **Step 5: Commit failing tests**
+
+```bash
+cd ~/Gits/huskyci-api-errgroup
+git add api/securitytest/runner.go api/securitytest/run.go api/securitytest/run_test.go
+git commit -m "test(securitytest): add TDD tests for errgroup error propagation
+
+Tests verify: first error cancels remaining, concurrent errors
+don't panic, all-pass returns nil. These currently FAIL."
+```
+
+---
+
+### Task 3: GREEN — Refactor to errgroup + scanRunner
+
+- [ ] **Step 1: Replace imports in run.go**
+
+```go
+import (
+	"context"
+	"os"
+	"strings"
+
+	apiContext "github.com/githubanotaai/huskyci-api/api/context"
+	"github.com/githubanotaai/huskyci-api/api/log"
+	"github.com/githubanotaai/huskyci-api/api/types"
+	"golang.org/x/sync/errgroup"
+)
+```
+
+- [ ] **Step 2: Replace Start()**
+
+```go
+func (results *RunAllInfo) Start(enryScan SecTestScanInfo) error {
+	results.Codes = enryScan.Codes
+	defer results.setToAnalysis()
+
+	g, ctx := errgroup.WithContext(context.Background())
+
+	g.Go(func() error {
+		return results.runGenericScans(ctx, enryScan)
+	})
+	g.Go(func() error {
+		return results.runLanguageScans(ctx, enryScan)
+	})
+
+	if err := g.Wait(); err != nil {
+		results.ErrorFound = err
+		return err
+	}
+
+	results.setFinalResult()
+	return nil
+}
+```
+
+- [ ] **Step 3: Replace runGenericScans()**
+
+```go
+func (results *RunAllInfo) runGenericScans(ctx context.Context, enryScan SecTestScanInfo) error {
+	g, ctx := errgroup.WithContext(ctx)
+	runner := results.getRunner()
+
+	genericTests, err := runner.listGenericTests()
+	if err != nil {
+		return err
+	}
+
+	for i := range genericTests {
+		if isTestDisabled(genericTests[i].Name) {
+			log.Info("runGenericScans", "SECURITYTEST", 0, "Skipping disabled test: "+genericTests[i].Name)
+			continue
+		}
+		g.Go(func() error {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
+
+			scan, err := runner.newScan(enryScan.RID, enryScan.URL, enryScan.Branch, genericTests[i].Name, nil, enryScan.DockerHost)
+			if err != nil {
+				return err
+			}
+			if err := runner.startScan(scan); err != nil {
+				return err
+			}
+			results.Containers = append(results.Containers, scan.Container)
+			switch genericTests[i].Name {
+			case "gitauthors":
+				results.CommitAuthors = scan.CommitAuthors.Authors
+			case "gitleaks", "wizcli":
+				results.setVulns(*scan)
+			}
+			return nil
+		})
+	}
+
+	return g.Wait()
+}
+```
+
+- [ ] **Step 4: Replace runLanguageScans()**
+
+```go
+func (results *RunAllInfo) runLanguageScans(ctx context.Context, enryScan SecTestScanInfo) error {
+	g, ctx := errgroup.WithContext(ctx)
+	runner := results.getRunner()
+
+	languageTests := []types.SecurityTest{}
+	for _, code := range enryScan.Codes {
+		codeTests, err := runner.listLanguageTests(code.Language)
+		if err != nil {
+			return err
+		}
+		languageTests = append(languageTests, codeTests...)
+	}
+
+	for i := range languageTests {
+		if isTestDisabled(languageTests[i].Name) {
+			log.Info("runLanguageScans", "SECURITYTEST", 0, "Skipping disabled test: "+languageTests[i].Name)
+			continue
+		}
+		g.Go(func() error {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
+
+			scan, err := runner.newScan(enryScan.RID, enryScan.URL, enryScan.Branch, languageTests[i].Name, nil, enryScan.DockerHost)
+			if err != nil {
+				return err
+			}
+			if err := runner.startScan(scan); err != nil {
+				results.Containers = append(results.Containers, scan.Container)
+				return err
+			}
+			results.Containers = append(results.Containers, scan.Container)
+			results.setVulns(*scan)
+			return nil
+		})
+	}
+
+	return g.Wait()
+}
+```
+
+- [ ] **Step 5: Run TDD tests — verify they PASS**
+
+```bash
+cd ~/Gits/huskyci-api-errgroup/api
+go test -v -run "TestStart_First|TestStart_Concurrent|TestStart_All" ./securitytest/
+```
+
+Expected: ALL PASS.
+
+- [ ] **Step 6: Run existing tests — no regression**
+
+```bash
+cd ~/Gits/huskyci-api-errgroup/api
+go test -v ./securitytest/
+```
+
+Expected: ALL PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd ~/Gits/huskyci-api-errgroup
+git add api/securitytest/run.go api/securitytest/runner.go
+git commit -m "refactor(securitytest): replace channel pattern with errgroup + scanRunner
+
+Start(), runGenericScans(), runLanguageScans() use errgroup.WithContext.
+scanRunner interface enables mock injection for tests.
+Fixes enryScan.LanguageExclusions shared mutation.
+Eliminates send-on-closed-channel panic."
+```
+
+---
+
+### Task 4: Final verification and push
+
+- [ ] **Step 1: Run full suite with race detector**
+
+```bash
+cd ~/Gits/huskyci-api-errgroup/api
+go test -race ./...
+```
+
+Expected: PASS (note: data race on Container append still exists — that's Bug 2, fixed in Plan 2).
+
+- [ ] **Step 2: Verify no old channel patterns**
+
+```bash
+cd ~/Gits/huskyci-api-errgroup
+grep -n "syncChan\|errChan\|waitChan\|sync\.WaitGroup" api/securitytest/run.go
+```
+
+Expected: No matches.
+
+- [ ] **Step 3: go vet**
+
+```bash
+cd ~/Gits/huskyci-api-errgroup/api
+go vet ./...
+```
+
+- [ ] **Step 4: Push**
+
+```bash
+cd ~/Gits/huskyci-api-errgroup
+git push -u origin fix/errgroup-channel-race
+```
+
+---
+
+## Self-Review
+
+**TDD cycle:**
+- Task 2: RED (tests fail — old channel pattern, no scanRunner)
+- Task 3: GREEN (errgroup + scanRunner makes all 3 tests pass)
+- Task 4: commit + verify
+
+**Scope:** Only Bug 1 (send-on-closed-channel). Bug 2 (data race) intentionally left for Plan 2.
+
+**Placeholder scan:** No TBD/TODO. All code inline.
+
+**Type consistency:**
+- `scanRunner.listGenericTests()` → `[]types.SecurityTest, error` matches `getAllDefaultSecurityTests`
+- `runner.newScan()` returns `*SecTestScanInfo` — callers use `*scan` / `*scan` in setVulns
+- `context.Context` threaded through runGenericScans, runLanguageScans

--- a/docs/superpowers/plans/2026-05-22-mutex-data-race.md
+++ b/docs/superpowers/plans/2026-05-22-mutex-data-race.md
@@ -1,0 +1,292 @@
+# Fix 2: Mutex Data Race — Implementation Plan (TDD)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Eliminate data races on shared `RunAllInfo` fields by adding `sync.Mutex`.
+
+**Architecture:** Add `sync.Mutex` to `RunAllInfo`, wrap concurrent mutations (Container append, CommitAuthors, setVulns). Lock scope is minimal — I/O stays outside. This branch is based on Fix 1 (errgroup already applied).
+
+**Tech Stack:** Go 1.20, sync.Mutex (stdlib)
+
+**Depends on:** Fix 1 branch `fix/errgroup-channel-race` must be complete first.
+
+---
+
+### Task 1: Create worktree from errgroup branch
+
+- [ ] **Step 1: Create branch and worktree**
+
+```bash
+cd ~/Gits/huskyci-api
+git branch fix/mutex-data-race fix/errgroup-channel-race
+git worktree add ../huskyci-api-mutex fix/mutex-data-race
+```
+
+- [ ] **Step 2: Verify base compiles**
+
+```bash
+cd ~/Gits/huskyci-api-mutex/api
+go build ./...
+```
+
+Expected: SUCCESS.
+
+- [ ] **Step 3: Verify existing TDD tests pass**
+
+```bash
+cd ~/Gits/huskyci-api-mutex/api
+go test -v -run "TestStart_First|TestStart_Concurrent|TestStart_All" ./securitytest/
+```
+
+Expected: ALL PASS (errgroup tests from Fix 1).
+
+---
+
+### Task 2: RED — Write failing data race tests
+
+- [ ] **Step 1: Write concurrent append test**
+
+Add to `api/securitytest/run_test.go` — ensure imports include `"fmt"`, `"sync"`:
+
+```go
+func TestRunAllInfoConcurrentAppend(t *testing.T) {
+	// Bug 2: concurrent append to results.Containers is a data race.
+	// Under -race flag this should report DATA RACE until mutex is added.
+	results := &RunAllInfo{}
+
+	const concurrency = 50
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+
+	for i := 0; i < concurrency; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			results.Containers = append(results.Containers, types.Container{
+				CID:     fmt.Sprintf("container-%d", idx),
+				CResult: "passed",
+			})
+		}(i)
+	}
+
+	wg.Wait()
+
+	if len(results.Containers) != concurrency {
+		t.Errorf("expected %d containers, got %d", concurrency, len(results.Containers))
+	}
+}
+```
+
+- [ ] **Step 2: Write concurrent setVulns test**
+
+```go
+func TestRunAllInfoConcurrentSetVulns(t *testing.T) {
+	// Bug 2: concurrent setVulns calls race on HuskyCIResults fields.
+	results := &RunAllInfo{}
+
+	const concurrency = 20
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+
+	for i := 0; i < concurrency; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			scanInfo := SecTestScanInfo{
+				SecurityTestName: bandit,
+				Vulnerabilities: types.HuskyCISecurityTestOutput{
+					HighVulns: []types.HuskyCIVulnerability{
+						{Code: fmt.Sprintf("vuln-%d", idx)},
+					},
+				},
+			}
+			results.setVulns(scanInfo)
+		}(i)
+	}
+
+	wg.Wait()
+
+	highCount := len(results.HuskyCIResults.PythonResults.HuskyCIBanditOutput.HighVulns)
+	if highCount != concurrency {
+		t.Errorf("expected %d high vulns, got %d", concurrency, highCount)
+	}
+}
+```
+
+- [ ] **Step 3: Run with race detector — verify DATA RACE detected**
+
+```bash
+cd ~/Gits/huskyci-api-mutex/api
+go test -race -v -run "TestRunAllInfoConcurrent" ./securitytest/ 2>&1 | head -30
+```
+
+Expected: `DATA RACE` reported by race detector, or wrong container count (append race loses entries).
+
+- [ ] **Step 4: Commit failing race tests**
+
+```bash
+cd ~/Gits/huskyci-api-mutex
+git add api/securitytest/run_test.go
+git commit -m "test(securitytest): add failing data race tests for RunAllInfo
+
+TestRunAllInfoConcurrentAppend and TestRunAllInfoConcurrentSetVulns
+expose Bug 2 under -race flag. Currently FAIL."
+```
+
+---
+
+### Task 3: GREEN — Add sync.Mutex and wrap mutations
+
+- [ ] **Step 1: Add sync import and mutex field**
+
+In `api/securitytest/run.go`, update imports — add `"sync"`:
+
+```go
+import (
+	"context"
+	"os"
+	"strings"
+	"sync"
+
+	apiContext "github.com/githubanotaai/huskyci-api/api/context"
+	"github.com/githubanotaai/huskyci-api/api/log"
+	"github.com/githubanotaai/huskyci-api/api/types"
+	"golang.org/x/sync/errgroup"
+)
+```
+
+Update `RunAllInfo` struct — add mutex field:
+
+```go
+type RunAllInfo struct {
+	mu             sync.Mutex `json:"-" bson:"-"`
+	runner         scanRunner `json:"-" bson:"-"`
+	RID            string
+	Status         string
+	Containers     []types.Container
+	CommitAuthors  []string
+	Codes          []types.Code
+	FinalResult    string
+	ErrorFound     error
+	HuskyCIResults types.HuskyCIResults
+}
+```
+
+- [ ] **Step 2: Wrap mutations in runGenericScans goroutine**
+
+In `runGenericScans`, replace the result mutation block with:
+
+```go
+			results.mu.Lock()
+			results.Containers = append(results.Containers, scan.Container)
+			switch genericTests[i].Name {
+			case "gitauthors":
+				results.CommitAuthors = scan.CommitAuthors.Authors
+			case "gitleaks", "wizcli":
+				results.setVulns(*scan)
+			}
+			results.mu.Unlock()
+			return nil
+```
+
+- [ ] **Step 3: Wrap mutations in runLanguageScans goroutine**
+
+Error path:
+
+```go
+			if err := runner.startScan(scan); err != nil {
+				results.mu.Lock()
+				results.Containers = append(results.Containers, scan.Container)
+				results.mu.Unlock()
+				return err
+			}
+```
+
+Success path:
+
+```go
+			results.mu.Lock()
+			results.Containers = append(results.Containers, scan.Container)
+			results.setVulns(*scan)
+			results.mu.Unlock()
+			return nil
+```
+
+- [ ] **Step 4: Run race tests — verify they PASS**
+
+```bash
+cd ~/Gits/huskyci-api-mutex/api
+go test -race -v -run "TestRunAllInfoConcurrent" ./securitytest/
+```
+
+Expected: ALL PASS — no DATA RACE warnings, correct container/vuln counts.
+
+- [ ] **Step 5: Run ALL tests — no regression**
+
+```bash
+cd ~/Gits/huskyci-api-mutex/api
+go test -race -v ./securitytest/
+```
+
+Expected: ALL PASS — errgroup tests + race tests + old isTestDisabled.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd ~/Gits/huskyci-api-mutex
+git add api/securitytest/run.go
+git commit -m "fix(securitytest): add sync.Mutex to RunAllInfo for data race protection
+
+Mutex wraps Container append, CommitAuthors assignment, and setVulns.
+Lock scope minimal — I/O stays outside. json/bson tags prevent serialization."
+```
+
+---
+
+### Task 4: Final verification and push
+
+- [ ] **Step 1: Run full suite with race detector**
+
+```bash
+cd ~/Gits/huskyci-api-mutex/api
+go test -race ./...
+```
+
+- [ ] **Step 2: Verify all mutation sites guarded**
+
+```bash
+cd ~/Gits/huskyci-api-mutex
+grep -n "results.Containers = append\|results.CommitAuthors\|results.setVulns" api/securitytest/run.go | grep -v "mu.Lock\|mu.Unlock"
+```
+
+Expected: No output — all sites have locks.
+
+- [ ] **Step 3: go vet**
+
+```bash
+cd ~/Gits/huskyci-api-mutex/api
+go vet ./...
+```
+
+- [ ] **Step 4: Push**
+
+```bash
+cd ~/Gits/huskyci-api-mutex
+git push -u origin fix/mutex-data-race
+```
+
+---
+
+## Self-Review
+
+**TDD cycle:**
+- Task 2: RED (race tests fail under `-race`)
+- Task 3: GREEN (mutex makes all tests pass)
+- Task 4: commit + verify
+
+**Scope:** Only Bug 2 (data race). Bug 1 already fixed by Fix 1 base branch.
+
+**Placeholder scan:** No TBD/TODO. All code inline.
+
+**Type consistency:**
+- `sync.Mutex` with `json:"-" bson:"-"` — `registerFinishedAnalysis` uses explicit `bson.M`
+- Lock/unlock pairs symmetric — each Lock has exactly one Unlock on same code path
+- `setVulns(*scan)` called inside lock — scan is already fully populated before lock

--- a/docs/superpowers/plans/2026-05-27-wizcli-three-way-split.md
+++ b/docs/superpowers/plans/2026-05-27-wizcli-three-way-split.md
@@ -1,0 +1,989 @@
+# WizCLI Three-Way Split Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Split the monolithic `wizcli` security test into three independent tests (`wizcli_secrets`, `wizcli_iac_sast`, `wizcli_vulns`) that run in parallel with independent timeout budgets, and extend the Wiz JSON parser to surface all scanner types (IaC, SAST, Malware, AIModels, SoftwareSupplyChain) instead of silently dropping them.
+
+**Architecture:** Three new HuskyCI Generic security tests replace the old single `wizcli` test. Each uses the same Docker image but different `--disabled-scanners` flags via the new `wizcli scan dir` syntax. The Go parser (`wizCLIReport` + `parseWizCLIJSON`) is extended with new struct fields and extraction loops for the 5 missing scanners. The old `wizcli` config block, wiring, and all references are removed entirely. Client output and summary are updated to show three WizCLI result groups.
+
+**Tech Stack:** Go (HuskyCI API + Client), YAML (config), Shell (pod commands), Wiz CLI v1.48+
+
+---
+
+## Decisions Locked (Grilling Session 2026-05-27)
+
+| ID | Decision |
+|----|----------|
+| D1 | Three tests: `wizcli_secrets`, `wizcli_iac_sast`, `wizcli_vulns` |
+| D2 | Use `wizcli scan dir` syntax (not legacy `wizcli dir scan`) |
+| D3 | `--disabled-scanners` controls which scanners run per test |
+| D4 | `--by-policy-hits=DISABLED` on all three tests |
+| D5 | Keep Wiz CLI `latest` in Dockerfile (no version pin) |
+| D6 | Remove old monolithic `wizcli` entirely (no disabled fallback) |
+| D7 | Same Docker image for all three tests, flags differ in `cmd` |
+| D8 | Same parser (`analyzeWizCLI` + `parseWizCLIJSON`) for all three |
+| D9 | Same `setVulns` routing for all three in `runGenericScans` |
+| D10 | Extend parser for `iac`, `sast`, `malwares`, `aiModels`, `softwareSupplyChain` |
+| D11 | No `--types` restriction — let Wiz auto-detect IaC types |
+| D12 | No diff-based filtering — scan all tracked files |
+| D13 | Timeouts: `wizcli_secrets`=120s, `wizcli_iac_sast`=300s, `wizcli_vulns`=300s |
+
+## Scanner Mapping
+
+| `--disabled-scanners` value | `result.*` JSON key | Test that enables it |
+|---|---|---|
+| Vulnerability | `libraries` + `osPackages` | `wizcli_vulns` |
+| Secret | `secrets` | `wizcli_secrets` |
+| SensitiveData | `dataFindings` | `wizcli_secrets` |
+| Misconfiguration | `iac` | `wizcli_iac_sast` |
+| SAST | `sast` | `wizcli_iac_sast` |
+| Malware | `malwares` | `wizcli_vulns` |
+| AIModels | `aiModels` | `wizcli_vulns` |
+| SoftwareSupplyChain | `softwareSupplyChain` | `wizcli_vulns` |
+| *(always-on)* | `endOfLifeTechnologies` | all three |
+
+## `--disabled-scanners` per Test
+
+| Test | Disabled scanners |
+|---|---|
+| `wizcli_secrets` | `Vulnerability,Misconfiguration,SAST,Malware,AIModels,SoftwareSupplyChain` |
+| `wizcli_iac_sast` | `Vulnerability,Secret,SensitiveData,Malware,AIModels,SoftwareSupplyChain` |
+| `wizcli_vulns` | `Secret,SensitiveData,Misconfiguration,SAST,AIModels,SoftwareSupplyChain` |
+
+---
+
+## HuskyCI Security Test Touchpoint Map
+
+Every security test in HuskyCI requires changes across **12 touchpoints**. This plan walks through each one in dependency order. The touchpoints also serve as the checklist for the skill and documentation deliverable.
+
+```
+Touchpoint  1: api/config.yaml                              — test definition (image, cmd, type, timeout)
+Touchpoint  2: api/types/types.go                            — output struct field in HuskyCIResults
+Touchpoint  3: api/context/context.go                        — APIConfig field + SetOnceConfig wiring
+Touchpoint  4: api/util/api/api.go                           — MongoDB upsert list + checkSecurityTest switch
+Touchpoint  5: api/securitytest/securitytest.go              — securityTestAnalyze dispatch map
+Touchpoint  6: api/securitytest/<scanner>.go                 — analyze* func + parser structs + parseJSON
+Touchpoint  7: api/securitytest/run.go                       — runGenericScans switch + setVulns switch (4×)
+Touchpoint  8: api/securitytest/<scanner>_test.go            — unit tests
+Touchpoint  9: client/types/types.go                         — mirror output structs + summary fields
+Touchpoint 10: client/analysis/output.go                     — output formatting + summary aggregation
+Touchpoint 11: client/analysis/output_wiz_test.go            — client output tests
+Touchpoint 12: client/integration/sonarqube/                 — SonarQube external issue integration
+```
+
+---
+
+## Task 1: api/config.yaml — Replace `wizcli` block with three new blocks
+
+**Touchpoint:** 1  
+**Objective:** Remove the monolithic `wizcli:` config and add three new config blocks using the new `wizcli scan dir` syntax with `--disabled-scanners` and `--by-policy-hits=DISABLED`.
+
+**Files:** Modify: `api/config.yaml`
+
+**Step 1:** Replace the entire `wizcli:` block with three new blocks:
+
+```yaml
+wizcli_secrets:
+  name: wizcli_secrets
+  image: 939030204144.dkr.ecr.us-east-1.amazonaws.com/huskyci-wiz
+  imageTag: "latest-amd64"
+  cmd: |+
+    mkdir -p ~/.ssh &&
+    echo '%GIT_PRIVATE_SSH_KEY%' > ~/.ssh/huskyci_id_rsa &&
+    chmod 600 ~/.ssh/huskyci_id_rsa &&
+    echo "IdentityFile ~/.ssh/huskyci_id_rsa" >> /etc/ssh/ssh_config &&
+    echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
+    GIT_TERMINAL_PROMPT=0 git clone -b %GIT_BRANCH% --single-branch --depth 1 %GIT_REPO% code --quiet 2>/tmp/errorGitCloneWiz
+    if [ $? -eq 0 ]; then
+        wizcli auth --id '%WIZ_CLIENT_ID%' --secret '%WIZ_CLIENT_SECRET%' > /tmp/errorWizAuth 2>&1
+        if [ $? -ne 0 ]; then
+            echo 'ERROR_AUTH_WIZCLI'
+            cat /tmp/errorWizAuth
+        else
+            wizcli scan dir ./code \
+              --disabled-scanners Vulnerability,Misconfiguration,SAST,Malware,AIModels,SoftwareSupplyChain \
+              --by-policy-hits=DISABLED \
+              --stdout=json --json-output-file=/tmp/wizResult.json 2> /tmp/errorWizScan
+            SCAN_RC=$?
+            if [ $SCAN_RC -ge 2 ]; then
+              echo "ERROR_RUNNING_WIZCLI_SCAN"
+              cat /tmp/errorWizScan
+            else
+              cat /tmp/wizResult.json
+            fi
+        fi
+    else
+        echo "ERROR_CLONING"
+        cat /tmp/errorGitCloneWiz
+    fi
+  type: Generic
+  default: true
+  timeOutInSeconds: 120
+
+wizcli_iac_sast:
+  name: wizcli_iac_sast
+  image: 939030204144.dkr.ecr.us-east-1.amazonaws.com/huskyci-wiz
+  imageTag: "latest-amd64"
+  cmd: |+
+    mkdir -p ~/.ssh &&
+    echo '%GIT_PRIVATE_SSH_KEY%' > ~/.ssh/huskyci_id_rsa &&
+    chmod 600 ~/.ssh/huskyci_id_rsa &&
+    echo "IdentityFile ~/.ssh/huskyci_id_rsa" >> /etc/ssh/ssh_config &&
+    echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
+    GIT_TERMINAL_PROMPT=0 git clone -b %GIT_BRANCH% --single-branch --depth 1 %GIT_REPO% code --quiet 2>/tmp/errorGitCloneWiz
+    if [ $? -eq 0 ]; then
+        wizcli auth --id '%WIZ_CLIENT_ID%' --secret '%WIZ_CLIENT_SECRET%' > /tmp/errorWizAuth 2>&1
+        if [ $? -ne 0 ]; then
+            echo 'ERROR_AUTH_WIZCLI'
+            cat /tmp/errorWizAuth
+        else
+            wizcli scan dir ./code \
+              --disabled-scanners Vulnerability,Secret,SensitiveData,Malware,AIModels,SoftwareSupplyChain \
+              --by-policy-hits=DISABLED \
+              --stdout=json --json-output-file=/tmp/wizResult.json 2> /tmp/errorWizScan
+            SCAN_RC=$?
+            if [ $SCAN_RC -ge 2 ]; then
+              echo "ERROR_RUNNING_WIZCLI_SCAN"
+              cat /tmp/errorWizScan
+            else
+              cat /tmp/wizResult.json
+            fi
+        fi
+    else
+        echo "ERROR_CLONING"
+        cat /tmp/errorGitCloneWiz
+    fi
+  type: Generic
+  default: true
+  timeOutInSeconds: 300
+
+wizcli_vulns:
+  name: wizcli_vulns
+  image: 939030204144.dkr.ecr.us-east-1.amazonaws.com/huskyci-wiz
+  imageTag: "latest-amd64"
+  cmd: |+
+    mkdir -p ~/.ssh &&
+    echo '%GIT_PRIVATE_SSH_KEY%' > ~/.ssh/huskyci_id_rsa &&
+    chmod 600 ~/.ssh/huskyci_id_rsa &&
+    echo "IdentityFile ~/.ssh/huskyci_id_rsa" >> /etc/ssh/ssh_config &&
+    echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
+    GIT_TERMINAL_PROMPT=0 git clone -b %GIT_BRANCH% --single-branch --depth 1 %GIT_REPO% code --quiet 2>/tmp/errorGitCloneWiz
+    if [ $? -eq 0 ]; then
+        wizcli auth --id '%WIZ_CLIENT_ID%' --secret '%WIZ_CLIENT_SECRET%' > /tmp/errorWizAuth 2>&1
+        if [ $? -ne 0 ]; then
+            echo 'ERROR_AUTH_WIZCLI'
+            cat /tmp/errorWizAuth
+        else
+            wizcli scan dir ./code \
+              --disabled-scanners Secret,SensitiveData,Misconfiguration,SAST,AIModels,SoftwareSupplyChain \
+              --by-policy-hits=DISABLED \
+              --stdout=json --json-output-file=/tmp/wizResult.json 2> /tmp/errorWizScan
+            SCAN_RC=$?
+            if [ $SCAN_RC -ge 2 ]; then
+              echo "ERROR_RUNNING_WIZCLI_SCAN"
+              cat /tmp/errorWizScan
+            else
+              cat /tmp/wizResult.json
+            fi
+        fi
+    else
+        echo "ERROR_CLONING"
+        cat /tmp/errorGitCloneWiz
+    fi
+  type: Generic
+  default: true
+  timeOutInSeconds: 300
+```
+
+**Verify:** `python3 -c "import yaml; yaml.safe_load(open('api/config.yaml'))"` — no errors.  
+**Commit:** `feat: split wizcli into 3 security tests in config.yaml`
+
+---
+
+## Task 2: api/types/types.go — Replace single WizCLI output field with three
+
+**Touchpoint:** 2  
+**Objective:** Replace `HuskyCIWizCLIOutput` in `GenericResults` with three output fields for the three split tests. Update `Summary` struct to have three WizCLI summary fields.
+
+**Files:** Modify: `api/types/types.go`
+
+**Step 1:** In `GenericResults` struct (line 133-137), replace:
+```go
+type GenericResults struct {
+    HuskyCIGitleaksOutput  HuskyCISecurityTestOutput `bson:"gitleaksoutput,omitempty" json:"gitleaksoutput,omitempty"`
+    HuskyCIWizCLIOutput    HuskyCISecurityTestOutput `bson:"wizclioutput,omitempty" json:"wizclioutput,omitempty"`
+}
+```
+with:
+```go
+type GenericResults struct {
+    HuskyCIGitleaksOutput      HuskyCISecurityTestOutput `bson:"gitleaksoutput,omitempty" json:"gitleaksoutput,omitempty"`
+    HuskyCIWizCLISecretsOutput HuskyCISecurityTestOutput `bson:"wizclisecretsoutput,omitempty" json:"wizclisecretsoutput,omitempty"`
+    HuskyCIIacSastOutput       HuskyCISecurityTestOutput `bson:"iavsastoutput,omitempty" json:"iavsastoutput,omitempty"`
+    HuskyCIWizCLIVulnsOutput   HuskyCISecurityTestOutput `bson:"wizclivulnsoutput,omitempty" json:"wizclivulnsoutput,omitempty"`
+}
+```
+
+**Step 2:** In `Summary` struct (line 189), replace:
+```go
+WizCLISummary           HuskyCISummary `json:"wizclisummary,omitempty"`
+```
+with:
+```go
+WizCLISecretsSummary   HuskyCISummary `json:"wizclisecretssummary,omitempty"`
+WizCLIIacSastSummary   HuskyCISummary `json:"wizcliiacsastsummary,omitempty"`
+WizCLIVulnsSummary      HuskyCISummary `json:"wizclivulnssummary,omitempty"`
+```
+
+**Verify:** `cd api/types && go build ./...` — will have compile errors in downstream files (expected, fixed in later tasks).  
+**Commit:** `feat: replace single WizCLI output with three in api types`
+
+---
+
+## Task 3: api/context/context.go — Replace WizcliSecurityTest with three fields
+
+**Touchpoint:** 3  
+**Objective:** Update the Go config struct to hold three new security test configs instead of one.
+
+**Files:** Modify: `api/context/context.go`
+
+**Step 1:** In the `APIConfig` struct, replace:
+```go
+WizcliSecurityTest           *types.SecurityTest
+```
+with:
+```go
+WizcliiacSastSecurityTest    *types.SecurityTest
+WizcliSecretsSecurityTest     *types.SecurityTest
+WizcliVulnsSecurityTest       *types.SecurityTest
+```
+
+**Step 2:** In `SetOnceConfig` function, replace:
+```go
+WizcliSecurityTest:           dF.getSecurityTestConfig("wizcli"),
+```
+with:
+```go
+WizcliiacSastSecurityTest:     dF.getSecurityTestConfig("wizcli_iac_sast"),
+WizcliSecretsSecurityTest:     dF.getSecurityTestConfig("wizcli_secrets"),
+WizcliVulnsSecurityTest:       dF.getSecurityTestConfig("wizcli_vulns"),
+```
+
+**Verify:** `cd api/context && go build ./...` — compile errors in `api/util/api/api.go` expected.  
+**Commit:** `feat: replace WizcliSecurityTest with three fields in APIConfig`
+
+---
+
+## Task 4: api/util/api/api.go — Update MongoDB seeding and security test switch
+
+**Touchpoint:** 4  
+**Objective:** Replace `wizcli` in the upsert list with the three new test names, and update the `checkSecurityTest` switch.
+
+**Files:** Modify: `api/util/api/api.go`
+
+**Step 1:** In `checkEachSecurityTest` upsert list, replace `"wizcli"` with `"wizcli_secrets", "wizcli_iac_sast", "wizcli_vulns"`.
+
+**Step 2:** In `checkSecurityTest` switch, replace:
+```go
+case "wizcli":
+    securityTestConfig = *configAPI.WizcliSecurityTest
+```
+with:
+```go
+case "wizcli_secrets":
+    securityTestConfig = *configAPI.WizcliSecretsSecurityTest
+case "wizcli_iac_sast":
+    securityTestConfig = *configAPI.WizcliiacSastSecurityTest
+case "wizcli_vulns":
+    securityTestConfig = *configAPI.WizcliVulnsSecurityTest
+```
+
+**Verify:** `cd api/util/api && go build ./...` — PASS.  
+**Commit:** `feat: seed three wizcli test configs into MongoDB`
+
+---
+
+## Task 5: api/securitytest/securitytest.go — Update securityTestAnalyze dispatch map
+
+**Touchpoint:** 5  
+**Objective:** Map the three new test names to `analyzeWizCLI` in the dispatch map. Remove old `"wizcli"` entry.
+
+**Files:** Modify: `api/securitytest/securitytest.go`
+
+**Step 1:** In `securityTestAnalyze` map (line 18-32), replace:
+```go
+"wizcli":           analyzeWizCLI,
+```
+with:
+```go
+"wizcli_secrets":   analyzeWizCLI,
+"wizcli_iac_sast":  analyzeWizCLI,
+"wizcli_vulns":     analyzeWizCLI,
+```
+
+**Verify:** `cd api/securitytest && go build ./...` — may have errors in `run.go` (fixed in Task 7).  
+**Commit:** `feat: dispatch three wizcli test names to analyzeWizCLI`
+
+---
+
+## Task 6: api/securitytest/wizcli.go — Extend parser struct + extraction loops
+
+**Touchpoint:** 6  
+**Objective:** Add Go struct fields for 5 missing scanner result types so `json.Unmarshal` captures them, then add extraction loops in `parseWizCLIJSON`.
+
+**Files:** Modify: `api/securitytest/wizcli.go`
+
+**Step 1: Add new struct types** (after `wizEndOfLifeFinding`):
+
+```go
+type wizIacFinding struct {
+    Name        string `json:"name"`
+    Description string `json:"description"`
+    Severity    string `json:"severity"`
+    File        string `json:"file"`
+    Line        int    `json:"line"`
+    Rule        string `json:"rule"`
+}
+
+type wizSastFinding struct {
+    Name        string `json:"name"`
+    Description string `json:"description"`
+    Severity    string `json:"severity"`
+    File        string `json:"file"`
+    Line        int    `json:"line"`
+    Rule        string `json:"rule"`
+}
+
+type wizMalwareFinding struct {
+    Name        string `json:"name"`
+    Description string `json:"description"`
+    Severity    string `json:"severity"`
+    Path        string `json:"path"`
+}
+
+type wizAIModelFinding struct {
+    Name     string `json:"name"`
+    Version  string `json:"version"`
+    Severity string `json:"severity"`
+    Path     string `json:"path"`
+}
+
+type wizSupplyChainFinding struct {
+    Name     string `json:"name"`
+    Version  string `json:"version"`
+    Severity string `json:"severity"`
+    License  string `json:"license"`
+    Path     string `json:"path"`
+}
+```
+
+**Step 2: Add fields to `wizCLIReport.Result`** (after `EndOfLifeTechnologies`):
+
+```go
+Iac                 []wizIacFinding         `json:"iac"`
+Sast                 []wizSastFinding        `json:"sast"`
+Malwares            []wizMalwareFinding      `json:"malwares"`
+AIModels            []wizAIModelFinding      `json:"aiModels"`
+SoftwareSupplyChain []wizSupplyChainFinding  `json:"softwareSupplyChain"`
+```
+
+**Step 3: Add 5 extraction loops** in `parseWizCLIJSON` (after the existing `endOfLifeTechnologies` loop). Each follows the same `addFinding(title, severity, file, line, details)` pattern used by the existing loops:
+
+- **IaC:** extract from `report.Result.Iac` — title from `Name` (fallback `Rule`), severity from `Severity` (default `"MEDIUM"`), file from `File`, line from `Line`, details from `Description`
+- **SAST:** extract from `report.Result.Sast` — same pattern as IaC
+- **Malware:** extract from `report.Result.Malwares` — title from `Name`, default severity `"HIGH"`, path from `Path`
+- **AIModels:** extract from `report.Result.AIModels` — title from `Name`, default severity `"INFO"`, details = `Name:Version`
+- **SoftwareSupplyChain:** extract from `report.Result.SoftwareSupplyChain` — title from `Name`, default severity `"MEDIUM"`, details = `Name:Version (license: License)`
+
+**Verify:** `cd api/securitytest && go build ./...`  
+**Commit:** `feat: extend wizCLI parser with iac, sast, malware, aiModels, softwareSupplyChain`
+
+---
+
+## Task 7: api/securitytest/run.go — Update runGenericScans switch + setVulns (4× switch blocks)
+
+**Touchpoint:** 7  
+**Objective:** Replace `case "wizcli"` in the `runGenericScans` switch and all four `setVulns` severity switch blocks (HighVulns, MediumVulns, LowVulns, NoSecVulns) with three new cases routing to the new `GenericResults` fields.
+
+**Files:** Modify: `api/securitytest/run.go`
+
+**Step 1:** In `runGenericScans` (around line 107), replace:
+```go
+case "gitleaks", "wizcli":
+    results.setVulns(*scan)
+```
+with:
+```go
+case "gitleaks", "wizcli_secrets", "wizcli_iac_sast", "wizcli_vulns":
+    results.setVulns(*scan)
+```
+
+**Step 2:** In `setVulns` — **all four switch blocks** (HighVulns ~line 185, MediumVulns ~line 212, LowVulns ~line 239, NoSecVulns ~line 266), replace each occurrence of:
+```go
+case wizcli:
+    results.HuskyCIResults.GenericResults.HuskyCIWizCLIOutput.HighVulns = append(...)
+```
+with three new cases:
+```go
+case "wizcli_secrets":
+    results.HuskyCIResults.GenericResults.HuskyCIWizCLISecretsOutput.HighVulns = append(...)
+case "wizcli_iac_sast":
+    results.HuskyCIResults.GenericResults.HuskyCIIacSastOutput.HighVulns = append(...)
+case "wizcli_vulns":
+    results.HuskyCIResults.GenericResults.HuskyCIWizCLIVulnsOutput.HighVulns = append(...)
+```
+
+Repeat for MediumVulns, LowVulns, NoSecVulns sections (changing `.HighVulns` to `.MediumVulns`, `.LowVulns`, `.NoSecVulns` respectively).
+
+Note: `bandit`, `brakeman`, etc. are string constants defined in `run.go`. If `wizcli` is defined as a constant, remove it and add three new constants:
+```go
+wizcliSecrets   = "wizcli_secrets"
+wizcliIacSast   = "wizcli_iac_sast"
+wizcliVulns     = "wizcli_vulns"
+```
+
+**Verify:** `cd api/securitytest && go build ./...` — PASS  
+**Commit:** `feat: route three wizcli tests to separate GenericResults fields in setVulns`
+
+---
+
+## Task 8: api/securitytest/wizcli_test.go — Add parser tests for 5 new scanner types
+
+**Touchpoint:** 8  
+**Objective:** Add unit tests for each new scanner type plus a null-safety test.
+
+**Files:** Modify: `api/securitytest/wizcli_test.go`
+
+Add these test cases:
+
+1. `TestParseWizCLIJSON_IacFindings` — populates `result.iac` with one IaC finding, asserts Title, Severity, Line extracted correctly
+2. `TestParseWizCLIJSON_SastFindings` — populates `result.sast`, same pattern
+3. `TestParseWizCLIJSON_MalwareFindings` — populates `result.malwares`, same pattern
+4. `TestParseWizCLIJSON_AIModelFindings` — populates `result.aiModels`, same pattern
+5. `TestParseWizCLIJSON_SoftwareSupplyChainFindings` — populates `result.softwareSupplyChain`, asserts Details contains license info
+6. `TestParseWizCLIJSON_NullNewFieldsIsNoError` — all 5 new fields as `null`, expects 0 findings and no error
+
+**Verify:** `cd api/securitytest && go test -v -run "TestParseWizCLIJSON" -count=1` — all PASS  
+**Commit:** `test: add parser tests for iac, sast, malwares, aiModels, softwareSupplyChain`
+
+---
+
+## Task 9: client/types/types.go — Mirror output structs + summary fields
+
+**Touchpoint:** 9  
+**Objective:** Mirror the API-side `GenericResults` and `Summary` changes in the client types package so the client can deserialize the new JSON structure.
+
+**Files:** Modify: `client/types/types.go`
+
+**Step 1:** In `GenericResults` struct (line 152-156), replace:
+```go
+type GenericResults struct {
+    HuskyCIGitleaksOutput HuskyCISecurityTestOutput `bson:"gitleaksoutput,omitempty" json:"gitleaksoutput,omitempty"`
+    HuskyCIWizCLIOutput   HuskyCISecurityTestOutput `bson:"wizclioutput,omitempty" json:"wizclioutput,omitempty"`
+}
+```
+with:
+```go
+type GenericResults struct {
+    HuskyCIGitleaksOutput      HuskyCISecurityTestOutput `bson:"gitleaksoutput,omitempty" json:"gitleaksoutput,omitempty"`
+    HuskyCIWizCLISecretsOutput HuskyCISecurityTestOutput `bson:"wizclisecretsoutput,omitempty" json:"wizclisecretsoutput,omitempty"`
+    HuskyCIIacSastOutput       HuskyCISecurityTestOutput `bson:"iavsastoutput,omitempty" json:"iavsastoutput,omitempty"`
+    HuskyCIWizCLIVulnsOutput   HuskyCISecurityTestOutput `bson:"wizclivulnsoutput,omitempty" json:"wizclivulnsoutput,omitempty"`
+}
+```
+
+**Step 2:** In `Summary` struct (line 189), replace:
+```go
+WizCLISummary           HuskyCISummary `json:"wizclisummary,omitempty"`
+```
+with:
+```go
+WizCLISecretsSummary   HuskyCISummary `json:"wizclisecretssummary,omitempty"`
+WizCLIIacSastSummary   HuskyCISummary `json:"wizcliiacsastsummary,omitempty"`
+WizCLIVulnsSummary      HuskyCISummary `json:"wizclivulnssummary,omitempty"`
+```
+
+**Verify:** `cd client/types && go build ./...` — will have errors in `client/analysis/output.go` (fixed in Task 10)  
+**Commit:** `feat: mirror three wizcli output fields in client types`
+
+---
+
+## Task 10: client/analysis/output.go — Update output formatting + summary aggregation
+
+**Touchpoint:** 10  
+**Objective:** Replace all references to `HuskyCIWizCLIOutput` and `WizCLISummary` with the three new fields. Update print, summary, and exit-code logic.
+
+**Files:** Modify: `client/analysis/output.go`
+
+**Step 1: STDOUT print** (~line 54-55). Replace:
+```go
+printToolGroup("Generic - Wiz CLI", outputJSON.GenericResults.HuskyCIWizCLIOutput, printSTDOUTOutputWizCLI)
+```
+with:
+```go
+printToolGroup("Generic - Wiz CLI (Secrets)", outputJSON.GenericResults.HuskyCIWizCLISecretsOutput, printSTDOUTOutputWizCLI)
+printToolGroup("Generic - Wiz CLI (IaC+SAST)", outputJSON.GenericResults.HuskyCIIacSastOutput, printSTDOUTOutputWizCLI)
+printToolGroup("Generic - Wiz CLI (Vulns)", outputJSON.GenericResults.HuskyCIWizCLIVulnsOutput, printSTDOUTOutputWizCLI)
+```
+
+**Step 2: Summary aggregation** (~line 186-195). Replace all `WizCLISummary` / `HuskyCIWizCLIOutput` references with three separate summaries that aggregate from each output field:
+```go
+// WizCLI Secrets summary
+outputJSON.Summary.WizCLISecretsSummary.NoSecVuln = len(outputJSON.GenericResults.HuskyCIWizCLISecretsOutput.NoSecVulns)
+outputJSON.Summary.WizCLISecretsSummary.LowVuln = len(outputJSON.GenericResults.HuskyCIWizCLISecretsOutput.LowVulns)
+outputJSON.Summary.WizCLISecretsSummary.MediumVuln = len(outputJSON.GenericResults.HuskyCIWizCLISecretsOutput.MediumVulns)
+outputJSON.Summary.WizCLISecretsSummary.HighVuln = len(outputJSON.GenericResults.HuskyCIWizCLISecretsOutput.HighVulns)
+// ... same pattern for WizCLIIacSastSummary and WizCLIVulnsSummary
+```
+
+For `FoundInfo` / `FoundVuln`, any of the three triggers the flag:
+```go
+if len(secrets.LowVulns) > 0 || len(iacSast.LowVulns) > 0 || len(vulns.LowVulns) > 0 || ... {
+    outputJSON.Summary.WizCLISecretsSummary.FoundInfo = true
+    // set FoundInfo on all three if any has findings
+}
+```
+
+Or simpler: set `FoundInfo`/`FoundVuln` independently per summary.
+
+**Step 3: Exit-code logic** (~line 221-235). Replace all `WizCLISummary` references in the `FoundVuln` / `FoundInfo` / total-count lines with the three new summary fields:
+```go
+// In FoundVuln check:
+outputJSON.Summary.WizCLISecretsSummary.FoundVuln || outputJSON.Summary.WizCLIIacSastSummary.FoundVuln || outputJSON.Summary.WizCLIVulnsSummary.FoundVuln
+// In total counts:
+totalNoSec += outputJSON.Summary.WizCLISecretsSummary.NoSecVuln + outputJSON.Summary.WizCLIIacSastSummary.NoSecVuln + outputJSON.Summary.WizCLIVulnsSummary.NoSecVuln
+// ... same for LowVuln, MediumVuln, HighVuln
+```
+
+**Verify:** `cd client/analysis && go build ./...`  
+**Commit:** `feat: update client output formatting for three wizcli result groups`
+
+---
+
+## Task 11: client/analysis/output_wiz_test.go — Update client output tests
+
+**Touchpoint:** 11  
+**Objective:** Update existing WizCLI output tests to use the three new output fields instead of the single `HuskyCIWizCLIOutput`.
+
+**Files:** Modify: `client/analysis/output_wiz_test.go`
+
+Replace all occurrences of `HuskyCIWizCLIOutput` in test data with `HuskyCIWizCLISecretsOutput` (or distribute across the three as appropriate for each test scenario). Replace `WizCLISummary` with the three summary fields.
+
+**Verify:** `cd client/analysis && go test -v -run "TestPrintSTDOUTOutput_IncludesWizCLI" -count=1`  
+**Commit:** `test: update client output tests for three wizcli result groups`
+
+---
+
+## Task 12: client/integration/sonarqube/ — Update SonarQube integration
+
+**Touchpoint:** 12  
+**Objective:** Update SonarQube external issue generation to collect findings from all three WizCLI output fields instead of one.
+
+**Files:** Modify: `client/integration/sonarqube/sonarqube.go`
+
+**Step 1:** In the vulnerability collection section (~line 62-65), replace:
+```go
+allVulns = append(allVulns, analysis.HuskyCIResults.GenericResults.HuskyCIWizCLIOutput.LowVulns...)
+allVulns = append(allVulns, analysis.HuskyCIResults.GenericResults.HuskyCIWizCLIOutput.MediumVulns...)
+allVulns = append(allVulns, analysis.HuskyCIResults.GenericResults.HuskyCIWizCLIOutput.HighVulns...)
+```
+with:
+```go
+allVulns = append(allVulns, analysis.HuskyCIResults.GenericResults.HuskyCIWizCLISecretsOutput.LowVulns...)
+allVulns = append(allVulns, analysis.HuskyCIResults.GenericResults.HuskyCIWizCLISecretsOutput.MediumVulns...)
+allVulns = append(allVulns, analysis.HuskyCIResults.GenericResults.HuskyCIWizCLISecretsOutput.HighVulns...)
+allVulns = append(allVulns, analysis.HuskyCIResults.GenericResults.HuskyCIIacSastOutput.LowVulns...)
+allVulns = append(allVulns, analysis.HuskyCIResults.GenericResults.HuskyCIIacSastOutput.MediumVulns...)
+allVulns = append(allVulns, analysis.HuskyCIResults.GenericResults.HuskyCIIacSastOutput.HighVulns...)
+allVulns = append(allVulns, analysis.HuskyCIResults.GenericResults.HuskyCIWizCLIVulnsOutput.LowVulns...)
+allVulns = append(allVulns, analysis.HuskyCIResults.GenericResults.HuskyCIWizCLIVulnsOutput.MediumVulns...)
+allVulns = append(allVulns, analysis.HuskyCIResults.GenericResults.HuskyCIWizCLIVulnsOutput.HighVulns...)
+```
+
+**Step 2:** Update `sonarqube_wizcli_test.go` test data to use `HuskyCIWizCLISecretsOutput` instead of `HuskyCIWizCLIOutput`.
+
+**Step 3:** Update testdata JSON fixtures if they reference `wizclioutput` → `wizclisecretsoutput` / `iavsastoutput` / `wizclivulnsoutput`.
+
+**Verify:** `cd client/integration/sonarqube && go test -v -count=1`  
+**Commit:** `feat: update SonarQube integration for three wizcli result groups`
+
+---
+
+## Task 13: Full regression check
+
+**Step 1:** `cd api && go test ./... -count=1` — all PASS  
+**Step 2:** `cd client && go test ./... -count=1` — all PASS  
+**Step 3:** `cd api && go vet ./...` — no issues  
+**Step 4:** `cd client && go vet ./...` — no issues  
+**Step 5:** Commit any fixes if needed
+
+---
+
+## Summary: All Files Changed
+
+| # | File | Touchpoint(s) | Change |
+|---|---|---|---|
+| 1 | `api/config.yaml` | 1 | Remove `wizcli:` block, add 3 new blocks |
+| 2 | `api/types/types.go` | 2 | Replace `HuskyCIWizCLIOutput` → 3 fields in `GenericResults` + `Summary` |
+| 3 | `api/context/context.go` | 3 | Replace `WizcliSecurityTest` → 3 fields + `SetOnceConfig` |
+| 4 | `api/context/context_test.go` | 3 | Update test assertions |
+| 5 | `api/util/api/api.go` | 4 | Upsert list + `checkSecurityTest` switch |
+| 6 | `api/securitytest/securitytest.go` | 5 | `securityTestAnalyze` dispatch map |
+| 7 | `api/securitytest/wizcli.go` | 6 | 5 new structs + 5 new Result fields + 5 extraction loops |
+| 8 | `api/securitytest/wizcli_test.go` | 8 | 6 new test cases |
+| 9 | `api/securitytest/run.go` | 7 | `runGenericScans` switch + `setVulns` 4× switch blocks |
+| 10 | `client/types/types.go` | 9 | Mirror `GenericResults` + `Summary` changes |
+| 11 | `client/analysis/output.go` | 10 | Print formatting + summary aggregation + exit-code logic |
+| 12 | `client/analysis/output_wiz_test.go` | 11 | Update test data |
+| 13 | `client/integration/sonarqube/sonarqube.go` | 12 | Collect from 3 output fields |
+| 14 | `client/integration/sonarqube/sonarqube_wizcli_test.go` | 12 | Update test data |
+| 15 | `client/integration/sonarqube/testdata/` | 12 | Update JSON fixtures |
+
+## Deployment Notes
+
+- **MongoDB:** Old `wizcli` document becomes orphaned on next API startup. The 3 new documents are upserted automatically. Manually delete the old `wizcli` document or leave inert.
+- **Wiz CLI version:** All three tests use the same Docker image (`latest-amd64`). The `--disabled-scanners` flag requires Wiz CLI v1.48+. Current Dockerfile pulls `latest`.
+- **Timeout tuning:** Initial timeouts (120s / 300s / 300s) are estimates. Monitor pod execution times and adjust.
+- **Parser field accuracy:** New struct fields are based on inferred JSON shapes. If field names differ, findings are silently skipped (same as today). Validate with real Wiz output in production.
+- **Backward compatibility:** Client JSON output shape changes (`wizclioutput` → `wizclisecretsoutput` + `iavsastoutput` + `wizclivulnsoutput`). Any downstream consumers parsing this JSON will need updating.
+
+---
+
+## DEPLOYMENT PHASE
+
+The 12 touchpoints above cover HuskyCI **code changes**. But a security test is not live until its container image is in ECR and the API deployment picks up the new config. This phase covers everything from code merge to a running test in production.
+
+### Release Tracks
+
+HuskyCI has three release tracks in `k8s-infrastructure-live`:
+
+| Track | Path | When to change |
+|---|---|---|
+| `unreleased` | `components/huskyci/unreleased/` | **This plan.** Every code change targets this track. |
+| `next` | `components/huskyci/next/` | Manual — when promoting unreleased → next |
+| `stable` | `components/huskyci/stable/` | Manual — when promoting next → stable |
+
+**Rule:** Only update `unreleased/`. `next` and `stable` promotions are done manually by the team.
+
+---
+
+## Task 14: Validate security test output before implementing parser changes
+
+**Objective:** Before writing or modifying any Go parser code, capture the **real JSON output** from the security test tool to verify struct field names and nesting. This prevents the most dangerous bug class: spec-to-code divergence where the parser silently drops findings because JSON keys don't match.
+
+**When to do this:** Before Task 6 (parser changes). This is a **gate** — parser implementation must not proceed until output is validated.
+
+**Steps:**
+
+1. **Run the test tool locally** against a representative repo:
+   ```sh
+   cd /tmp
+   git clone --depth 1 git@github.com:githubanotaai/infrastructure.git wiz-output-test
+   cd wiz-output-test
+   ~/wizcli scan dir . \
+     --disabled-scanners <SCANNERS_FOR_YOUR_TEST> \
+     --by-policy-hits=DISABLED \
+     --stdout=json --json-output-file=/tmp/wiz-real-output.json
+   ```
+
+2. **Inspect the JSON structure** — focus on the `result.*` keys you're adding:
+   ```sh
+   python3 -c "
+   import json
+   with open('/tmp/wiz-real-output.json') as f:
+       data = json.load(f)
+   result = data.get('result', {})
+   for key, val in result.items():
+       if val is not None:
+           print(f'{key}: type={type(val).__name__}, len={len(val) if isinstance(val, list) else \"N/A\"}')
+           if isinstance(val, list) and len(val) > 0:
+               print(f'  sample: {json.dumps(val[0], indent=2)[:500]}')
+   "
+   ```
+
+3. **Compare against parser structs** — verify every JSON field name matches the Go struct tag. Common mismatches:
+   - `snake_case` JSON vs `CamelCase` Go tags
+   - Nested objects the parser flattens
+   - Optional fields that may be absent vs empty string
+   - `null` vs absent key (both must parse without error)
+
+4. **If mismatches found** — update the struct definitions in Task 6 before implementing
+
+**Output validation is mandatory for:**
+- New security tests (validate entire output shape)
+- Updated security tests where the tool version changed (check if output shape changed)
+- Parser extensions where existing test adds new scanners (validate new `result.*` keys)
+
+---
+
+## Task 15: Build and push scanner container image to ECR
+
+**Objective:** Build the Docker image for the security test scanner and push it to the `anotaai-platform-production` AWS account ECR.
+
+**When to do this:** After Task 14 (output validation) and Task 1 (config.yaml), before any deployment.
+
+**ECR details:**
+- **Account:** anotaai-platform-production (account ID: `939030204144`)
+- **Region:** `us-east-1`
+- **Repository:** `939030204144.dkr.ecr.us-east-1.amazonaws.com/huskyci-wiz`
+
+**Steps:**
+
+1. **AWS login** (using `ifood-aws-login`):
+   ```sh
+   ifood-aws-login -r idp-aai-sec-team
+   ```
+   This assumes the `idp-aai-sec-team` role has ECR push permissions. If not, use the appropriate role.
+
+2. **Docker ECR login:**
+   ```sh
+   aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 939030204144.dkr.ecr.us-east-1.amazonaws.com
+   ```
+
+3. **Build the image:**
+   ```sh
+   cd ~/Gits/huskyci-api
+   docker build -t 939030204144.dkr.ecr.us-east-1.amazonaws.com/huskyci-wiz:latest-amd64 \
+     -f deployments/dockerfiles/wizcli/Dockerfile .
+   ```
+
+4. **Push the image:**
+   ```sh
+   docker push 939030204144.dkr.ecr.us-east-1.amazonaws.com/huskyci-wiz:latest-amd64
+   ```
+
+5. **Verify the image is in ECR:**
+   ```sh
+   aws ecr describe-images --repository-name huskyci-wiz --region us-east-1 --registry-id 939030204144
+   ```
+
+**Note for new security tests:** If creating a brand-new scanner (not just updating wizcli), you also need to:
+- Create the ECR repository: `aws ecr create-repository --repository-name huskyci-<scanner-name> --region us-east-1`
+- Write a new `Dockerfile` under `deployments/dockerfiles/<scanner-name>/`
+
+---
+
+## Task 16: Build and push HuskyCI API container image to ECR
+
+**Objective:** The `huskyci-api` image contains `config.yaml` baked in. After changing `config.yaml` (Task 1), you must rebuild the API image.
+
+**ECR details:**
+- **Repository:** `939030204144.dkr.ecr.us-east-1.amazonaws.com/huskyci-api`
+
+**Steps:**
+
+1. **AWS login** (if not already logged in):
+   ```sh
+   ifood-aws-login -r idp-aai-sec-team
+   ```
+
+2. **Docker ECR login** (if not already logged in):
+   ```sh
+   aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 939030204144.dkr.ecr.us-east-1.amazonaws.com
+   ```
+
+3. **Build the API image:**
+   ```sh
+   cd ~/Gits/huskyci-api
+   docker build -t 939030204144.dkr.ecr.us-east-1.amazonaws.com/huskyci-api:prod.main.<SHORT_SHA>-amd64 \
+     -f deployments/dockerfiles/api.Dockerfile .
+   ```
+
+4. **Push:**
+   ```sh
+   docker push 939030204144.dkr.ecr.us-east-1.amazonaws.com/huskyci-api:prod.main.<SHORT_SHA>-amd64
+   ```
+
+5. **Note the image tag** — you'll need it in Task 17 to update `values.yaml`.
+
+---
+
+## Task 16b: Build and push HuskyCI Client container image to ECR
+
+**Objective:** Tasks 9-12 change the `client/` Go code. The client image is used as a **GitHub Actions container** in the `.github` org repo (`anotaai-sast.yml` workflow). After changing client code, you must rebuild the client image and update the workflow reference.
+
+**ECR details:**
+- **Repository:** `939030204144.dkr.ecr.us-east-1.amazonaws.com/huskyci-client`
+- **Current tag:** `prod.main.9045189-amd64-v2`
+
+**Steps:**
+
+1. **Build the client image:**
+   ```sh
+   cd ~/Gits/huskyci-api
+   docker build -t 939030204144.dkr.ecr.us-east-1.amazonaws.com/huskyci-client:prod.main.<SHORT_SHA>-amd64-v2 \
+     -f deployments/dockerfiles/client.Dockerfile .
+   ```
+
+2. **Push:**
+   ```sh
+   docker push 939030204144.dkr.ecr.us-east-1.amazonaws.com/huskyci-client:prod.main.<SHORT_SHA>-amd64-v2
+   ```
+
+3. **Update `.github` org repo** — the client image tag is hardcoded in the reusable workflow:
+   ```sh
+   cd ~/Gits/.github
+   ```
+   Edit `.github/workflows/anotaai-sast.yml` line 24:
+   ```yaml
+   # Before:
+   image: 939030204144.dkr.ecr.us-east-1.amazonaws.com/huskyci-client:prod.main.9045189-amd64-v2
+   # After:
+   image: 939030204144.dkr.ecr.us-east-1.amazonaws.com/huskyci-client:prod.main.<NEW_SHA>-amd64-v2
+   ```
+   Commit and push to `master`.
+
+4. **Important:** This change affects **all repos** in the `githubanotaai` org that use the SAST workflow. The image tag must be correct before pushing — a broken client image would block all CI pipelines.
+
+---
+
+## Task 17: Update k8s-infrastructure-live unreleased values.yaml
+
+**Objective:** Update the HuskyCI API deployment to use the new image tag that contains the three-test config.
+
+**Files:** Modify: `k8s-infrastructure-live/components/huskyci/unreleased/values.yaml`
+
+**Steps:**
+
+1. **Update `image.tag`** to the tag pushed in Task 16:
+   ```yaml
+   image:
+     repository: 939030204144.dkr.ecr.us-east-1.amazonaws.com/huskyci-api
+     pullPolicy: IfNotPresent
+     tag: "prod.main.<NEW_SHA>-amd64"
+   ```
+
+2. **Add disable flags** for the three new tests (if needed during rollout):
+   ```yaml
+   # Security test disable flags
+   - name: HUSKYCI_DISABLE_GITAUTHORS
+     value: "true"
+   # Uncomment to disable individual WizCLI tests:
+   # - name: HUSKYCI_DISABLE_WIZCLI_SECRETS
+   #   value: "true"
+   # - name: HUSKYCI_DISABLE_WIZCLI_IAC_SAST
+   #   value: "true"
+   # - name: HUSKYCI_DISABLE_WIZCLI_VULNS
+   #   value: "true"
+   ```
+
+3. **Commit and push** to the `unreleased` branch
+
+4. **Deploy** via GitOps (ArgoCD/Flux will pick up the change automatically, or manual apply)
+
+**Note:** `next/` and `stable/` values.yaml are updated **manually** when promoting releases. Do NOT modify them in this plan.
+
+---
+
+## Task 18: End-to-end validation
+
+**Objective:** Verify the three new security tests actually run in the deployed environment.
+
+**Steps:**
+
+1. **Trigger a HuskyCI scan** against a test repo (e.g., `infrastructure` or a small test repo):
+   ```sh
+   curl -X POST https://<huskyci-endpoint>/api/v1/token \
+     -H 'Content-Type: application/json' \
+     -d '{"repositoryURL":"git@github.com:githubanotaai/<test-repo>.git","repositoryBranch":"main"}'
+   ```
+
+2. **Check that three WizCLI pods are created** (one per test):
+   ```sh
+   kubectl get pods -n huskyci -l app=huskyci --sort-by='.status.startTime' | grep wizcli
+   ```
+
+3. **Check pod logs** for each test:
+   ```sh
+   kubectl logs -n huskyci <pod-name-wizcli-secrets>
+   kubectl logs -n huskyci <pod-name-wizcli-iac-sast>
+   kubectl logs -n huskyci <pod-name-wizcli-vulns>
+   ```
+
+4. **Check HuskyCI API response** — the analysis result should contain three separate output groups:
+   ```sh
+   curl https://<huskyci-endpoint>/api/v1/analysis/<RID>
+   ```
+   Verify `genericresults` contains `wizclisecretsoutput`, `iavsastoutput`, `wizclivulnsoutput` (not the old `wizclioutput`).
+
+5. **Check client output** — run the HuskyCI client and verify three WizCLI sections appear in the summary.
+
+6. **Check SonarQube** — if SonarQube integration is active, verify WizCLI findings from all three tests appear as external issues.
+
+---
+
+## COMPLETE SECURITY TEST LIFECYCLE CHECKLIST
+
+This checklist applies to **any** new or updated HuskyCI security test. Use it as the definitive reference.
+
+### A. Code Changes (12 Touchpoints)
+
+| # | File | What to change |
+|---|---|---|
+| 1 | `api/config.yaml` | Add/modify test block: name, image, cmd, type, default, timeOutInSeconds |
+| 2 | `api/types/types.go` | Add/modify output field in the appropriate `*Results` struct + `Summary` field |
+| 3 | `api/context/context.go` | Add/modify `APIConfig` field + `SetOnceConfig` wiring |
+| 4 | `api/util/api/api.go` | Add to `checkEachSecurityTest` upsert list + `checkSecurityTest` switch |
+| 5 | `api/securitytest/securitytest.go` | Add to `securityTestAnalyze` dispatch map: `name: analyzeFunc` |
+| 6 | `api/securitytest/<scanner>.go` | Write/modify `analyze*` func + parser structs + `parseJSON` func |
+| 7 | `api/securitytest/run.go` | Add to `runGenericScans` switch + `setVulns` 4× switch blocks (High/Med/Low/NoSec) |
+| 8 | `api/securitytest/<scanner>_test.go` | Write/modify parser unit tests |
+| 9 | `client/types/types.go` | Mirror API `*Results` + `Summary` struct changes |
+| 10 | `client/analysis/output.go` | Add/modify print formatting + summary aggregation + exit-code logic |
+| 11 | `client/analysis/output_<scanner>_test.go` | Write/modify client output tests |
+| 12 | `client/integration/sonarqube/` | Add/modify SonarQube collection + tests + testdata |
+
+### B. Output Validation (Gate — before parser implementation)
+
+| Step | Action |
+|---|---|
+| 1 | Run the security test tool locally against a representative repo |
+| 2 | Capture real JSON output with `--stdout=json` |
+| 3 | Inspect every `result.*` key — type, nesting, sample values |
+| 4 | Compare JSON keys against Go struct tags |
+| 5 | Fix any mismatches before writing parser code |
+
+### C. Container Image Build + ECR Push
+
+| Step | Action |
+|---|---|
+| 1 | AWS login: `ifood-aws-login -r idp-aai-sec-team` |
+| 2 | Docker ECR login: `aws ecr get-login-password \| docker login` |
+| 3 | Build scanner image: `docker build -t <ECR_REPO>:<TAG> -f Dockerfile .` |
+| 4 | Push scanner image: `docker push <ECR_REPO>:<TAG>` |
+| 5 | *(For new scanners)* Create ECR repo: `aws ecr create-repository` |
+| 6 | Build API image (contains config.yaml): `docker build -t huskyci-api:<TAG> -f api.Dockerfile .` |
+| 7 | Push API image: `docker push huskyci-api:<TAG>` |
+| 8 | *(If client code changed)* Build client image: `docker build -t huskyci-client:<TAG> -f client.Dockerfile .` |
+| 9 | *(If client code changed)* Push client image: `docker push huskyci-client:<TAG>` |
+| 10 | *(If client code changed)* Update `.github` org repo `anotaai-sast.yml` container image tag |
+
+### D. Deployment to k8s-infrastructure-live
+
+| Step | Action |
+|---|---|
+| 1 | Update `unreleased/values.yaml` image tag |
+| 2 | Add/update `HUSKYCI_DISABLE_*` env vars if needed |
+| 3 | Commit + push to unreleased track |
+| 4 | *(GitOps auto-deploys, or manual apply)* |
+| 5 | **DO NOT modify** `next/` or `stable/` — those are manual promotions |
+
+### E. End-to-End Validation
+
+| Step | Action |
+|---|---|
+| 1 | Trigger a HuskyCI scan against a test repo |
+| 2 | Verify pods are created with correct test names |
+| 3 | Check pod logs for expected output |
+| 4 | Check API response for correct output grouping |
+| 5 | Check client output for correct display |
+| 6 | Check SonarQube integration (if active) |
+
+### F. Post-Deployment
+
+| Step | Action |
+|---|---|
+| 1 | Monitor pod execution times — adjust timeouts if needed |
+| 2 | Monitor for timed-out pods — may need to adjust scan flags |
+| 3 | Check MongoDB for orphaned old test documents |
+| 4 | Update documentation/skill if any gotchas discovered |

--- a/docs/superpowers/plans/2026-05-27-wizcli-three-way-split.md
+++ b/docs/superpowers/plans/2026-05-27-wizcli-three-way-split.md
@@ -48,7 +48,7 @@
 |---|---|
 | `wizcli_secrets` | `Vulnerability,Misconfiguration,SAST,Malware,AIModels,SoftwareSupplyChain` |
 | `wizcli_iac_sast` | `Vulnerability,Secret,SensitiveData,Malware,AIModels,SoftwareSupplyChain` |
-| `wizcli_vulns` | `Secret,SensitiveData,Misconfiguration,SAST,AIModels,SoftwareSupplyChain` |
+| `wizcli_vulns` | `Secret,SensitiveData,Misconfiguration,SAST` |
 
 ---
 

--- a/docs/superpowers/plans/2026-05-27-wizcli-three-way-split.md
+++ b/docs/superpowers/plans/2026-05-27-wizcli-three-way-split.md
@@ -641,11 +641,12 @@ allVulns = append(allVulns, analysis.HuskyCIResults.GenericResults.HuskyCIWizCLI
 
 ## Deployment Notes
 
-- **MongoDB:** Old `wizcli` document becomes orphaned on next API startup. The 3 new documents are upserted automatically. Manually delete the old `wizcli` document or leave inert.
-- **Wiz CLI version:** All three tests use the same Docker image (`latest-amd64`). The `--disabled-scanners` flag requires Wiz CLI v1.48+. Current Dockerfile pulls `latest`.
+- **MongoDB:** Old `wizcli` document becomes orphaned on next API startup. The 3 new documents are upserted automatically. **Cleanup step:** After deploying, run `db.securityTest.deleteOne({name: "wizcli"})` in the HuskyCI MongoDB to remove the orphaned document. Leaving it inert is also safe — the API won't dispatch it.
+- **Image tags:** ECR tag immutability prevents re-pushing `latest-amd64`. This release uses commit-hash tags (e.g. `f793155-amd64` for scanner, `prod.main.<sha>-amd64` for API/client). Future releases will also use hash tags. To revert to `latest-amd64`, delete the old immutable tag in ECR first.
+- **Wiz CLI version:** All three tests use the same Docker image (`f793155-amd64`). The `--disabled-scanners` flag requires Wiz CLI v1.48+. Current Dockerfile pulls `latest`.
 - **Timeout tuning:** Initial timeouts (120s / 300s / 300s) are estimates. Monitor pod execution times and adjust.
 - **Parser field accuracy:** New struct fields are based on inferred JSON shapes. If field names differ, findings are silently skipped (same as today). Validate with real Wiz output in production.
-- **Backward compatibility:** Client JSON output shape changes (`wizclioutput` → `wizclisecretsoutput` + `iavsastoutput` + `wizclivulnsoutput`). Any downstream consumers parsing this JSON will need updating.
+- **Backward compatibility:** Client JSON output shape changes (`wizclioutput` → `wizclisecretsoutput` + `iacsastoutput` + `wizclivulnsoutput`). Any downstream consumers parsing this JSON will need updating.
 
 ---
 
@@ -985,5 +986,5 @@ This checklist applies to **any** new or updated HuskyCI security test. Use it a
 |---|---|
 | 1 | Monitor pod execution times — adjust timeouts if needed |
 | 2 | Monitor for timed-out pods — may need to adjust scan flags |
-| 3 | Check MongoDB for orphaned old test documents |
+| 3 | Delete orphaned `wizcli` document: `db.securityTest.deleteOne({name: "wizcli"})` |
 | 4 | Update documentation/skill if any gotchas discovered |


### PR DESCRIPTION
## Summary

Split the monolithic `wizcli` security test into three independent tests that run in parallel with separate timeout budgets:

- **`wizcli_secrets`** (Secret + SensitiveData, 120s)
- **`wizcli_iac_sast`** (Misconfiguration + SAST, 300s)
- **`wizcli_vulns`** (Vulnerability + Malware + AIModels + SoftwareSupplyChain, 300s)

Also extends the Wiz JSON parser to surface 5 previously-dropped scanner result types: `iac`, `sast`, `malwares`, `aiModels`, `softwareSupplyChain`.

### Changes (12 touchpoints)

**API side:**
- `api/config.yaml` — Replace `wizcli` block with 3 new blocks using `wizcli scan dir` syntax, `--disabled-scanners`, `--by-policy-hits=DISABLED`, `--stdout=json`
- `api/types/types.go` — `HuskyCIWizCLIOutput` → 3 fields, `WizCLISummary` → 3 summaries
- `api/context/context.go` + `_test.go` — `WizcliSecurityTest` → 3 config fields
- `api/util/api/api.go` + `_test.go` — MongoDB seeding: 3 test names, switch: 3 cases
- `api/securitytest/securitytest.go` — Dispatch map: 3 entries → `analyzeWizCLI`
- `api/securitytest/wizcli.go` — 5 new parser structs + extraction loops
- `api/securitytest/run.go` — 3 constants, `runGenericScans` case, 4× `setVulns` switch blocks
- `api/securitytest/wizcli_test.go` — 6 new parser tests

**Client side:**
- `client/types/types.go` — Mirror API-side type changes
- `client/analysis/output.go` — 3 print groups, 3 summary aggregations, exit-code logic
- `client/analysis/output_wiz_test.go` — Updated test fixtures
- `client/integration/sonarqube/` — Aggregated vulns from 3 fields, updated test + testdata

### Verification
- All 51 API tests pass ✅
- All client tests pass ✅
- Zero remaining references to old `wizcli`/`HuskyCIWizCLIOutput` ✅
- Images built and pushed to ECR ✅

### Decisions Locked
See plan doc `docs/superpowers/plans/2026-05-27-wizcli-three-way-split.md`

### Deployment PRs (merge in this order)
1. **This PR** — huskyci-api code changes
2. [k8s-infrastructure-live](https://github.com/githubanotaai/k8s-infrastructure-live/pull/new/feat/huskyci-wizcli-split) — staging values.yaml
3. [.github](https://github.com/githubanotaai/.github/pull/new/feat/huskyci-client-wizcli-split) — client workflow tag