### PR TITLE
fix: quote %GIT_BRANCH% and %GIT_REPO% in shell clone commands

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -8,7 +8,7 @@ enry:
     chmod 600 ~/.ssh/huskyci_id_rsa &&
     echo "IdentityFile ~/.ssh/huskyci_id_rsa" >> /etc/ssh/ssh_config &&
     echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
-    GIT_TERMINAL_PROMPT=0 git clone -b %GIT_BRANCH% --single-branch --depth 1 %GIT_REPO% code --quiet 2> /tmp/errorGitCloneEnry
+    GIT_TERMINAL_PROMPT=0 git clone -b "%GIT_BRANCH%" --single-branch --depth 1 "%GIT_REPO%" code --quiet 2> /tmp/errorGitCloneEnry
     if [ $? -eq 0 ]; then
       cd code
       enry --json | tr -d '\r\n' 2> /tmp/errorRunEnry
@@ -34,7 +34,7 @@ gitauthors:
     chmod 600 ~/.ssh/huskyci_id_rsa &&
     echo "IdentityFile ~/.ssh/huskyci_id_rsa" >> /etc/ssh/ssh_config &&
     echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
-    GIT_TERMINAL_PROMPT=0 git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneEnry
+    GIT_TERMINAL_PROMPT=0 git clone -b "%GIT_BRANCH%" --single-branch "%GIT_REPO%" code --quiet 2> /tmp/errorGitCloneEnry
     if [ $? -ne 0 ]; then
       echo "ERROR_CLONING"
       cat /tmp/errorGitCloneEnry
@@ -76,7 +76,7 @@ gosec:
       done
     fi
     cd src
-    GIT_TERMINAL_PROMPT=0 git clone -b %GIT_BRANCH% --single-branch --depth 1 %GIT_REPO% code --quiet 2> /tmp/errorGitCloneGosec
+    GIT_TERMINAL_PROMPT=0 git clone -b "%GIT_BRANCH%" --single-branch --depth 1 "%GIT_REPO%" code --quiet 2> /tmp/errorGitCloneGosec
     if [ $? -eq 0 ]; then
       cd code
       touch results.json
@@ -101,7 +101,7 @@ bandit:
      chmod 600 ~/.ssh/huskyci_id_rsa &&
      echo "IdentityFile ~/.ssh/huskyci_id_rsa" >> /etc/ssh/ssh_config &&
      echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
-     GIT_TERMINAL_PROMPT=0 git clone -b %GIT_BRANCH% --single-branch --depth 1 %GIT_REPO% code --quiet 2> /tmp/errorGitCloneBandit
+     GIT_TERMINAL_PROMPT=0 git clone -b "%GIT_BRANCH%" --single-branch --depth 1 "%GIT_REPO%" code --quiet 2> /tmp/errorGitCloneBandit
      if [ $? -eq 0 ]; then
        cd code
        chmod +x /usr/local/bin/husky-file-ignore.sh
@@ -127,7 +127,7 @@ brakeman:
     chmod 600 ~/.ssh/huskyci_id_rsa &&
     echo "IdentityFile ~/.ssh/huskyci_id_rsa" >> /etc/ssh/ssh_config &&
     echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
-    GIT_TERMINAL_PROMPT=0 git clone -b %GIT_BRANCH% --single-branch --depth 1 %GIT_REPO% code --quiet 2> /tmp/errorGitCloneBrakeman
+    GIT_TERMINAL_PROMPT=0 git clone -b "%GIT_BRANCH%" --single-branch --depth 1 "%GIT_REPO%" code --quiet 2> /tmp/errorGitCloneBrakeman
     if [ $? -eq 0 ]; then
       if [ -d /code/app ]; then
         if [ -f /code/brakeman.ignore ]; then
@@ -164,7 +164,7 @@ safety:
     chmod 600 ~/.ssh/huskyci_id_rsa &&
     echo "IdentityFile ~/.ssh/huskyci_id_rsa" >> /etc/ssh/ssh_config &&
     echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
-    GIT_TERMINAL_PROMPT=0 git clone -b %GIT_BRANCH% --single-branch --depth 1 %GIT_REPO% code --quiet 2> /tmp/errorGitCloneSafety
+    GIT_TERMINAL_PROMPT=0 git clone -b "%GIT_BRANCH%" --single-branch --depth 1 "%GIT_REPO%" code --quiet 2> /tmp/errorGitCloneSafety
     if [ $? -eq 0 ]; then
       cd code
       if [ -f Pipfile.lock ]; then
@@ -210,7 +210,7 @@ npmaudit:
     chmod 600 ~/.ssh/huskyci_id_rsa &&
     echo "IdentityFile ~/.ssh/huskyci_id_rsa" >> /etc/ssh/ssh_config &&
     echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
-    GIT_TERMINAL_PROMPT=0 git clone -b %GIT_BRANCH% --single-branch --depth 1 %GIT_REPO% code --quiet 2> /tmp/errorGitCloneNpmAudit
+    GIT_TERMINAL_PROMPT=0 git clone -b "%GIT_BRANCH%" --single-branch --depth 1 "%GIT_REPO%" code --quiet 2> /tmp/errorGitCloneNpmAudit
     if [ $? -eq 0 ]; then
       cd code
       if [ -f .npmrc ]; then
@@ -248,7 +248,7 @@ yarnaudit:
     chmod 600 ~/.ssh/huskyci_id_rsa &&
     echo "IdentityFile ~/.ssh/huskyci_id_rsa" >> /etc/ssh/ssh_config &&
     echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
-    GIT_TERMINAL_PROMPT=0 git clone -b %GIT_BRANCH% --single-branch --depth 1 %GIT_REPO% code --quiet 2> /tmp/errorGitCloneYarnAudit
+    GIT_TERMINAL_PROMPT=0 git clone -b "%GIT_BRANCH%" --single-branch --depth 1 "%GIT_REPO%" code --quiet 2> /tmp/errorGitCloneYarnAudit
     if [ $? -eq 0 ]; then
         cd code
         if [ -f yarn.lock ]; then
@@ -284,7 +284,7 @@ spotbugs:
     chmod 600 ~/.ssh/huskyci_id_rsa &&
     echo "IdentityFile ~/.ssh/huskyci_id_rsa" >> /etc/ssh/ssh_config &&
     echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
-    GIT_TERMINAL_PROMPT=0 git clone -b %GIT_BRANCH% --single-branch --depth 1 %GIT_REPO% code --quiet 2> /tmp/errorGitCloneSpotBugs
+    GIT_TERMINAL_PROMPT=0 git clone -b "%GIT_BRANCH%" --single-branch --depth 1 "%GIT_REPO%" code --quiet 2> /tmp/errorGitCloneSpotBugs
     if [ $? -eq 0 ]; then
        cd code
        if [ -f "pom.xml" ]; then
@@ -340,7 +340,7 @@ gitleaks:
     chmod 600 ~/.ssh/huskyci_id_rsa &&
     echo "IdentityFile ~/.ssh/huskyci_id_rsa" >> /etc/ssh/ssh_config &&
     echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
-    GIT_TERMINAL_PROMPT=0 git clone -b %GIT_BRANCH% --single-branch --depth 1 %GIT_REPO% code --quiet 2> /tmp/errorGitCloneGitleaks
+    GIT_TERMINAL_PROMPT=0 git clone -b "%GIT_BRANCH%" --single-branch --depth 1 "%GIT_REPO%" code --quiet 2> /tmp/errorGitCloneGitleaks
     if [ $? -eq 0 ]; then
         touch /tmp/results.json
         $(which gitleaks) dir ./code -f json -r /tmp/results.json --no-banner -l error 2> /tmp/errorGitleaks
@@ -372,7 +372,7 @@ tfsec:
     chmod 600 ~/.ssh/huskyci_id_rsa &&
     echo "IdentityFile ~/.ssh/huskyci_id_rsa" >> /etc/ssh/ssh_config &&
     echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
-    GIT_TERMINAL_PROMPT=0 git clone -b %GIT_BRANCH% --single-branch --depth 1 %GIT_REPO% code --quiet 2> /tmp/errorGitCloneTFSec
+    GIT_TERMINAL_PROMPT=0 git clone -b "%GIT_BRANCH%" --single-branch --depth 1 "%GIT_REPO%" code --quiet 2> /tmp/errorGitCloneTFSec
     if [ $? -eq 0 ]; then
         tfsec code --format=json > results.json 2> /tmp/tfsec_warnings.log
         if [ ! -s results.json ] || ! jq empty results.json 2>/dev/null; then
@@ -399,7 +399,7 @@ securitycodescan:
     chmod 600 ~/.ssh/huskyci_id_rsa &&
     echo "IdentityFile ~/.ssh/huskyci_id_rsa" >> /etc/ssh/ssh_config &&
     echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
-    GIT_TERMINAL_PROMPT=0 git clone -b %GIT_BRANCH% --single-branch --depth 1 %GIT_REPO% code --quiet 2> /tmp/errorGitCloneSecurityCodeScan
+    GIT_TERMINAL_PROMPT=0 git clone -b "%GIT_BRANCH%" --single-branch --depth 1 "%GIT_REPO%" code --quiet 2> /tmp/errorGitCloneSecurityCodeScan
     if [ $? -eq 0 ]; then
         cd code
         security-scan `find . -type f -name "*.sln"` --ignore-msbuild-errors --no-banner --export=/tmp/securityCodeScanResults.json > /tmp/securityCodeScanOutput 2>&1
@@ -428,7 +428,7 @@ wizcli_secrets:
     chmod 600 ~/.ssh/huskyci_id_rsa &&
     echo "IdentityFile ~/.ssh/huskyci_id_rsa" >> /etc/ssh/ssh_config &&
     echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
-    GIT_TERMINAL_PROMPT=0 git clone -b %GIT_BRANCH% --single-branch --depth 1 %GIT_REPO% code --quiet 2>/tmp/errorGitCloneWiz
+    GIT_TERMINAL_PROMPT=0 git clone -b "%GIT_BRANCH%" --single-branch --depth 1 "%GIT_REPO%" code --quiet 2>/tmp/errorGitCloneWiz
     if [ $? -eq 0 ]; then
         wizcli auth --id '%WIZ_CLIENT_ID%' --secret '%WIZ_CLIENT_SECRET%' > /tmp/errorWizAuth 2>&1
         if [ $? -ne 0 ]; then
@@ -465,7 +465,7 @@ wizcli_iac_sast:
     chmod 600 ~/.ssh/huskyci_id_rsa &&
     echo "IdentityFile ~/.ssh/huskyci_id_rsa" >> /etc/ssh/ssh_config &&
     echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
-    GIT_TERMINAL_PROMPT=0 git clone -b %GIT_BRANCH% --single-branch --depth 1 %GIT_REPO% code --quiet 2>/tmp/errorGitCloneWiz
+    GIT_TERMINAL_PROMPT=0 git clone -b "%GIT_BRANCH%" --single-branch --depth 1 "%GIT_REPO%" code --quiet 2>/tmp/errorGitCloneWiz
     if [ $? -eq 0 ]; then
         wizcli auth --id '%WIZ_CLIENT_ID%' --secret '%WIZ_CLIENT_SECRET%' > /tmp/errorWizAuth 2>&1
         if [ $? -ne 0 ]; then
@@ -502,7 +502,7 @@ wizcli_vulns:
     chmod 600 ~/.ssh/huskyci_id_rsa &&
     echo "IdentityFile ~/.ssh/huskyci_id_rsa" >> /etc/ssh/ssh_config &&
     echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
-    GIT_TERMINAL_PROMPT=0 git clone -b %GIT_BRANCH% --single-branch --depth 1 %GIT_REPO% code --quiet 2>/tmp/errorGitCloneWiz
+    GIT_TERMINAL_PROMPT=0 git clone -b "%GIT_BRANCH%" --single-branch --depth 1 "%GIT_REPO%" code --quiet 2>/tmp/errorGitCloneWiz
     if [ $? -eq 0 ]; then
         wizcli auth --id '%WIZ_CLIENT_ID%' --secret '%WIZ_CLIENT_SECRET%' > /tmp/errorWizAuth 2>&1
         if [ $? -ne 0 ]; then

--- a/api/util/util_test.go
+++ b/api/util/util_test.go
@@ -47,6 +47,15 @@ var _ = Describe("Util", func() {
 				Expect(util.HandleCmd(inputRepositoryURL, inputRepositoryBranch, "")).To(Equal(""))
 			})
 		})
+		Context("When branch name contains shell metacharacters like parentheses", func() {
+			It("Should substitute correctly when values are quoted in the template", func() {
+				quotedCmd := `git clone -b "%GIT_BRANCH%" --single-branch --depth 1 "%GIT_REPO%" code`
+				branchWithParens := "feat(ideia-intelligence)--add-service"
+				result := util.HandleCmd("git@github.com:org/repo.git", branchWithParens, quotedCmd)
+				expected := `git clone -b "feat(ideia-intelligence)--add-service" --single-branch --depth 1 "git@github.com:org/repo.git" code`
+				Expect(result).To(Equal(expected))
+			})
+		})
 	})
 
 	Describe("HandleGitURLSubstitution", func() {


### PR DESCRIPTION
## Problem

All HuskyCI security test pods that run git clone fail when branch names contain shell metacharacters like parentheses.

Example failing branches from the infrastructure repo:
- feat(ideia-intelligence)--add-service-configuration-and-IAM-role-for-pod-identity-with-S3-access
- feat(data/s3)--allow-bot-buscaai-cross-account-role-on-prod-s3-actions-kinesis
- chore(data-ingestion)--bucket-policy-for-bot-buscaai-Athena-results-(cross-account)

Pods error with: /bin/sh: syntax error: unexpected "("

## Root Cause

Pod containers run: Command: ["/bin/sh", "-c", cmd]

The cmd string from config.yaml substitutes %GIT_BRANCH% directly into the shell command without quoting. When the branch name contains (, /bin/sh interprets it as subshell syntax.

## Fix

Wrap %GIT_BRANCH% and %GIT_REPO% in double quotes in all git clone commands across all security test cmd templates in config.yaml.

Before: git clone -b %GIT_BRANCH% --single-branch --depth 1 %GIT_REPO% code
After: git clone -b "%GIT_BRANCH%" --single-branch --depth 1 "%GIT_REPO%" code

Why this is safe: HandleCmd() does pure strings.ReplaceAll -- quotes pass through correctly. Git branch names cannot contain double-quotes per Git ref naming rules. Double quotes in /bin/sh only scope the argument; they do not trigger pipe/subshell behavior.

Affected security tests: enry, gitauthors, gosec, bandit, brakeman, safety, npmaudit, yarnaudit, spotbugs, gitleaks, tfsec, securitycodescan, wizcli -- 16 git clone lines total.

## Test

Added Ginkgo test case verifying HandleCmd produces correct quoted output for branch names with parentheses. All 11 API test packages pass (0 failures).