### PR TITLE
fix: use --stdout=human to prevent duplicate JSON in wizcli container output

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -438,7 +438,7 @@ wizcli_secrets:
             wizcli scan dir ./code \
               --disabled-scanners Vulnerability,Misconfiguration,SAST,Malware,AIModels,SoftwareSupplyChain \
               --by-policy-hits=DISABLED \
-              --stdout=json --json-output-file=/tmp/wizResult.json 2> /tmp/errorWizScan
+              --stdout=human --json-output-file=/tmp/wizResult.json 2> /tmp/errorWizScan
             SCAN_RC=$?
             if [ $SCAN_RC -ge 2 ]; then
               echo "ERROR_RUNNING_WIZCLI_SCAN"
@@ -475,7 +475,7 @@ wizcli_iac_sast:
             wizcli scan dir ./code \
               --disabled-scanners Vulnerability,Secret,SensitiveData,Malware,AIModels,SoftwareSupplyChain \
               --by-policy-hits=DISABLED \
-              --stdout=json --json-output-file=/tmp/wizResult.json 2> /tmp/errorWizScan
+              --stdout=human --json-output-file=/tmp/wizResult.json 2> /tmp/errorWizScan
             SCAN_RC=$?
             if [ $SCAN_RC -ge 2 ]; then
               echo "ERROR_RUNNING_WIZCLI_SCAN"
@@ -512,7 +512,7 @@ wizcli_vulns:
             wizcli scan dir ./code \
               --disabled-scanners Secret,SensitiveData,Misconfiguration,SAST \
               --by-policy-hits=DISABLED \
-              --stdout=json --json-output-file=/tmp/wizResult.json 2> /tmp/errorWizScan
+              --stdout=human --json-output-file=/tmp/wizResult.json 2> /tmp/errorWizScan
             SCAN_RC=$?
             if [ $SCAN_RC -ge 2 ]; then
               echo "ERROR_RUNNING_WIZCLI_SCAN"


### PR DESCRIPTION
## Problem

`wizcli scan dir --stdout=json` emits JSON progress/status lines to stdout **during** the scan, then `cat /tmp/wizResult.json` dumps the full result at the end. This produces multiple concatenated JSON objects in the container output, which fails to parse:

```
wizcli json parse failed: invalid character '{' after top-level value
```

## Fix

Change `--stdout=json` → `--stdout=human` in all three wizcli commands. This keeps human-readable progress in the container logs (useful for debugging) while the scan result file remains the single source of truth for JSON parsing.

**Before:** stdout = JSON progress lines + JSON result → `cat` adds another copy → multiple JSON objects
**After:** stdout = human progress text + `cat /tmp/wizResult.json` → single clean JSON object

## Test Plan
- [x] API `go test ./...` passes
- [ ] Deploy to k8s and verify wizcli scans produce parseable JSON output