### PR TITLE
feat/test-suite-add-tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,93 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Three independent Go modules
+
+`api/`, `client/`, and `cli/` are separate Go modules — each has its own `go.mod`, `go.sum`, and `.golangci.yml`. You must `cd` into the relevant module to run `go` commands. Forgetting this is the #1 source of confusion.
+
+```sh
+cd api && go test -race ./...                     # run a module's tests
+cd api && go test -race -run TestCheckMalicious ./util  # single test
+cd api && go vet ./... && go build ./...
+cd api && golangci-lint run ./...                 # linter is v2.x with .golangci.yml per module
+```
+
+CI mirrors this layout: a matrix job runs vet/build/test against each of `api`, `client`, `cli` (Go 1.23) plus a separate `golangci-lint` job per module. See `.github/workflows/ci.yaml`.
+
+The linter config suppresses `ST*` (stylecheck) rules because the codebase has legacy naming conventions that are too invasive to fix safely (`api/.golangci.yml`). New code should still follow Go conventions; lowercase error strings without trailing punctuation.
+
+## Architecture: three-tier scan orchestration
+
+```
+huskyci-client (in CI runner pod)
+   │ POST /analysis  { repositoryURL, repositoryBranch, languageExclusions, changedFiles }
+   ▼
+huskyci-api (Echo HTTP server on :8888)
+   │ creates pods/containers per security tool
+   ▼
+Scanner pods/containers (enry, bandit, gosec, gitleaks, npm/yarn/pnpm audit, wizcli, …)
+   │ each clones the target repo, runs its tool, emits JSON on stdout
+   ▼
+API collects stdout, parses JSON per-tool, persists to MongoDB
+   │
+huskyci-client polls GET /analysis/:id, prints results, writes SonarQube JSON,
+   exits 190 if HIGH/MEDIUM vulns were found
+```
+
+Entrypoints: `api/server.go`, `client/cmd/main.go`, `cli/main.go`. Routes are wired in `api/routes/`. The Echo group `/api/1.0` requires basic auth (`HUSKYCI_API_DEFAULT_USERNAME/PASSWORD`); `/analysis*` use a custom `Husky-Token` header validated by `api/token`.
+
+### How a scan actually runs (analysis pipeline)
+
+`api/analysis/analysis.go::StartAnalysis` runs `enry` first to detect languages in the repo, then fans out two `errgroup.Group`s in `api/securitytest/run.go`:
+
+- `runGenericScans` — runs all `type: Generic` tests (enry, gitauthors, gitleaks, wizcli_*)
+- `runLanguageScans` — for each language enry found, runs each `type: Language` test whose `language:` matches (gosec, bandit, npmaudit, …)
+
+Each scan's lifecycle is driven by `SecTestScanInfo.Start()` in `api/securitytest/securitytest.go`:
+1. Substitute placeholders in `cmd` (`HandleCmd`, `HandleGitURLSubstitution`, `HandlePrivateSSHKey` in `api/util/util.go`).
+2. Run the container — `kubeRun` (`api/kubernetes/`) or `dockerRun` (`api/dockers/`), chosen by `HUSKYCI_INFRASTRUCTURE_USE` (`kubernetes` or `docker`).
+3. Capture stdout into `Container.COutput`.
+4. Call `securityTestAnalyze[name]` — one of the per-tool `analyze*` functions in `api/securitytest/<tool>.go`, which parses the JSON the tool wrote to stdout and populates `scan.Vulnerabilities`.
+5. `setVulns` merges that scan's vulns into the right field of `RunAllInfo.HuskyCIResults` (mapped in `vulnOutput`).
+
+The `scanRunner` interface in `api/securitytest/runner.go` lets tests substitute `mockRunner` for DB + container execution — use it when adding tests that exercise `runGenericScans`/`runLanguageScans`.
+
+### Adding a new scanner — checklist
+
+A new scanner is not a single-file change. Touch all of:
+
+1. `api/config.yaml` — add the YAML block with `name`, `image`, `imageTag`, `cmd`, `type` (`Generic` or `Language`), `language` (if Language), `default`, `timeOutInSeconds`. The `cmd` is a shell script with `%GIT_REPO%`, `%GIT_BRANCH%`, `%GIT_PRIVATE_SSH_KEY%`, `%CHANGED_FILES%`, and optionally `%WIZ_CLIENT_ID%`/`%WIZ_CLIENT_SECRET%` placeholders.
+2. `api/context/context.go` — add a `*types.SecurityTest` field to `APIConfig` and a `getSecurityTestConfig("name")` call in `SetOnceConfig`.
+3. `api/securitytest/securitytest.go` — register `"name": analyzeFoo` in `securityTestAnalyze`.
+4. `api/securitytest/foo.go` — implement `analyzeFoo(scanInfo *SecTestScanInfo) error` that unmarshals `scanInfo.Container.COutput` and appends to `scanInfo.Vulnerabilities.{High,Medium,Low}Vulns`.
+5. `api/securitytest/run.go` — add a `case` in `vulnOutput` returning a pointer into `HuskyCIResults`.
+6. `api/types/types.go` — extend `HuskyCIResults` / its sub-structs if the language group is new.
+7. The scanner config must also be seeded into MongoDB at deploy time — `getAllDefaultSecurityTests` reads from the `securityTest` collection, not from `config.yaml` directly.
+
+### Delta scanning
+
+When the client passes `changedFiles` (newline-separated paths) and the API sets `HUSKYCI_DELTA_SCAN=true` for a scanner via `HUSKYCI_SCANNER_<NAME>_DELTA_SCAN`, scanner `cmd` blocks take the sparse-checkout branch: `git clone --no-checkout` + `git sparse-checkout add` per file + `git checkout --`. If you edit the sparse-checkout shell blocks in `config.yaml`, **all** scanner blocks (bandit, gosec, gitleaks, wizcli_*) follow the same pattern — keep them in sync, and preserve the `ERROR_SPARSE_CHECKOUT` sentinel since `analyze()` in `securitytest.go` matches it. `changedFiles` is validated by `util.CheckMaliciousChangedFiles` to block shell metacharacters before it ever reaches the container.
+
+### Disabling tests at runtime
+
+`HUSKYCI_DISABLE_<TESTNAME>=true` (e.g. `HUSKYCI_DISABLE_GITLEAKS`) is checked by `isTestDisabled` in `run.go` before each scan starts — useful for cost/incident response without redeploying.
+
+## Database
+
+MongoDB is the production store (`api/db/mongo/mongo.go`). A Postgres backend exists in `api/db/postgres/` but is not wired up — the `docker-compose.yml` Postgres service is commented out. `db.Requests` (`api/db/huskydb.go`) is the interface both implementations satisfy.
+
+## Local dev environment
+
+`make compose` brings up the Docker-mode stack (API + MongoDB + dockerd-in-docker for scanner containers) via `deployments/docker-compose.yml`. `make install` runs `create-certs` → `compose` → `generate-passwords`. The K8s mode requires a real cluster; no docker-compose path exists for it.
+
+## CI contracts beyond unit tests
+
+`.github/workflows/ci.yaml` also enforces two contracts the unit suite can't:
+
+- **Gitleaks v8 + fixture finding.** Builds `deployments/dockerfiles/gitleaks/Dockerfile`, asserts the binary reports `v8.x`, then runs it on `api/securitytest/testdata/gitleaks_e2e_fixture` expecting **exactly one** finding with `RuleID: "github-pat"`. If you change the fixture or the gitleaks image, update both ends.
+- **Deployment shell `bash -n`.** `deployments/scripts/verify-depl-scripts.sh` syntax-checks the registry/push scripts. No registries are pushed from CI.
+
+## Exit codes from the client
+
+`190` is intentional and load-bearing: it tells the GitHub Action that the scan ran successfully but found blocking (HIGH/MEDIUM) vulnerabilities. Do not collapse it into `1` — operators distinguish "scan failed" from "scan found bugs" using this code.

--- a/api/auth/auth.go
+++ b/api/auth/auth.go
@@ -5,6 +5,8 @@
 package auth
 
 import (
+	"crypto/subtle"
+
 	"github.com/labstack/echo"
 )
 
@@ -32,7 +34,7 @@ func (mB MongoBasic) IsValidUser(username, password string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if passDB != hashedPass {
+	if subtle.ConstantTimeCompare([]byte(passDB), []byte(hashedPass)) != 1 {
 		return false, nil
 	}
 	return true, nil

--- a/api/config.yaml
+++ b/api/config.yaml
@@ -802,8 +802,44 @@ wizcli_vulns:
     chmod 600 ~/.ssh/huskyci_id_rsa &&
     echo "IdentityFile ~/.ssh/huskyci_id_rsa" >> /etc/ssh/ssh_config &&
     echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
-    GIT_TERMINAL_PROMPT=0 git clone -b "%GIT_BRANCH%" --single-branch --depth 1 "%GIT_REPO%" code --quiet 2>/tmp/errorGitCloneWiz
-    if [ $? -eq 0 ]; then
+    if [ "$HUSKYCI_DELTA_SCAN" = "true" ] && [ -n "%CHANGED_FILES%" ]; then
+      GIT_TERMINAL_PROMPT=0 git clone --no-checkout -b "%GIT_BRANCH%" --single-branch --depth 1 "%GIT_REPO%" code --quiet 2>/tmp/errorGitClone
+      if [ $? -eq 0 ]; then
+        cd code
+        git sparse-checkout init --cone
+        echo "%CHANGED_FILES%" | while IFS= read -r f; do [ -n "$f" ] && git sparse-checkout add "$f"; done
+        git checkout -- 2>/tmp/errorSparseCheckout
+        if [ $? -ne 0 ]; then
+          echo "ERROR_SPARSE_CHECKOUT"
+          cat /tmp/errorSparseCheckout
+          exit 1
+        fi
+        cd ..
+        wizcli auth --id '%WIZ_CLIENT_ID%' --secret '%WIZ_CLIENT_SECRET%' > /tmp/errorWizAuth 2>&1
+        if [ $? -ne 0 ]; then
+          echo 'ERROR_AUTH_WIZCLI'
+          cat /tmp/errorWizAuth
+        else
+          wizcli scan dir ./code \
+            --disabled-scanners Secret,SensitiveData,Misconfiguration,SAST \
+            --by-policy-hits=DISABLED \
+            --json-output-file=/tmp/wizResult.json > /dev/null 2> /tmp/errorWizScan
+          SCAN_RC=$?
+          if [ $SCAN_RC -ge 2 ]; then
+            echo "ERROR_RUNNING_WIZCLI_SCAN"
+            cat /tmp/errorWizScan
+          else
+            cat /tmp/wizResult.json
+          fi
+        fi
+      else
+        echo "ERROR_CLONING"
+        cat /tmp/errorGitClone
+        exit 1
+      fi
+    else
+      GIT_TERMINAL_PROMPT=0 git clone -b "%GIT_BRANCH%" --single-branch --depth 1 "%GIT_REPO%" code --quiet 2>/tmp/errorGitCloneWiz
+      if [ $? -eq 0 ]; then
         wizcli auth --id '%WIZ_CLIENT_ID%' --secret '%WIZ_CLIENT_SECRET%' > /tmp/errorWizAuth 2>&1
         if [ $? -ne 0 ]; then
             echo 'ERROR_AUTH_WIZCLI'
@@ -821,9 +857,10 @@ wizcli_vulns:
               cat /tmp/wizResult.json
             fi
         fi
-    else
+      else
         echo "ERROR_CLONING"
         cat /tmp/errorGitCloneWiz
+      fi
     fi
   type: Generic
   default: true

--- a/api/dockers/api.go
+++ b/api/dockers/api.go
@@ -6,17 +6,18 @@ package dockers
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"strconv"
+	"time"
 
+	goContext "context"
 	dockerTypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
 	apiContext "github.com/githubanotaai/huskyci-api/api/context"
 	"github.com/githubanotaai/huskyci-api/api/log"
-	goContext "context"
+	"github.com/githubanotaai/huskyci-api/api/util"
 )
 
 // Docker is the docker struct
@@ -99,6 +100,11 @@ func (d Docker) StartContainer() error {
 // WaitContainer returns when container finishes executing cmd.
 func (d Docker) WaitContainer(timeOutInSeconds int) error {
 	ctx := goContext.Background()
+	if timeOutInSeconds > 0 {
+		var cancel goContext.CancelFunc
+		ctx, cancel = goContext.WithTimeout(ctx, time.Duration(timeOutInSeconds)*time.Second)
+		defer cancel()
+	}
 	containerWaitC, errC := d.client.ContainerWait(ctx, d.CID, container.WaitConditionNotRunning)
 
 	select {
@@ -110,6 +116,8 @@ func (d Docker) WaitContainer(timeOutInSeconds int) error {
 		if containerWait.StatusCode != 0 {
 			return fmt.Errorf("Error in POST to wait the container with statusCode %d", containerWait.StatusCode)
 		}
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 
 	return nil
@@ -194,12 +202,12 @@ func (d Docker) ReadOutput() (string, error) {
 		return "", nil
 	}
 
-	body, err := io.ReadAll(out)
+	body, err := util.ReadBoundedScannerOutput(out)
 	if err != nil {
 		log.Error("ReadOutput", logInfoAPI, 3007, err)
 		return "", err
 	}
-	return string(body), err
+	return body, err
 }
 
 // ReadOutputStderr returns STDERR of a given containerID.
@@ -211,12 +219,12 @@ func (d Docker) ReadOutputStderr() (string, error) {
 		return "", nil
 	}
 
-	body, err := io.ReadAll(out)
+	body, err := util.ReadBoundedScannerOutput(out)
 	if err != nil {
 		log.Error("ReadOutputStderr", logInfoAPI, 3008, err)
 		return "", err
 	}
-	return string(body), err
+	return body, err
 }
 
 // PullImage pulls an image, like docker pull.

--- a/api/kubernetes/api.go
+++ b/api/kubernetes/api.go
@@ -7,11 +7,11 @@ package kubernetes
 import (
 	"errors"
 	"fmt"
-	"io"
 
+	goContext "context"
 	apiContext "github.com/githubanotaai/huskyci-api/api/context"
 	"github.com/githubanotaai/huskyci-api/api/log"
-	goContext "context"
+	"github.com/githubanotaai/huskyci-api/api/util"
 
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -244,7 +244,7 @@ func (k Kubernetes) ReadOutput(name string) (string, error) {
 	}
 	defer func() { _ = podLogs.Close() }()
 
-	result, err := io.ReadAll(podLogs)
+	result, err := util.ReadBoundedScannerOutput(podLogs)
 	if err != nil {
 		errRemovePod := k.RemovePod(name)
 		if errRemovePod != nil {
@@ -253,7 +253,7 @@ func (k Kubernetes) ReadOutput(name string) (string, error) {
 		return "", err
 	}
 
-	return string(result), nil
+	return result, nil
 }
 
 func (k Kubernetes) RemovePod(name string) error {

--- a/api/routes/analysis.go
+++ b/api/routes/analysis.go
@@ -75,7 +75,7 @@ func GetAnalysis(c echo.Context) error {
 	log.Info(logActionGetAnalysis, logInfoAnalysis, 113, "Analysis data retrieved successfully for RID:", RID)
 
 	// Add logging to capture the analysis result being returned
-	log.Info(logActionGetAnalysis, logInfoAnalysis, 113, "Analysis result:", analysisResult)
+	log.Info(logActionGetAnalysis, logInfoAnalysis, 113, "Analysis result:", analysisResult.RID, analysisResult.Status, analysisResult.Result)
 
 	return c.JSON(http.StatusOK, analysisResult)
 }
@@ -148,7 +148,7 @@ func ReceiveRequest(c echo.Context) error {
 		} else { // err == nil
 			// step 03-a: Ops, this analysis is already running!
 			if analysisResult.Status == "running" {
-				log.Warning(logActionReceiveRequest, logInfoAnalysis, 104, analysisResult.URL)
+				log.Warning(logActionReceiveRequest, logInfoAnalysis, 104, util.RedactURL(analysisResult.URL))
 				reply := map[string]interface{}{"success": false, "error": "an analysis is already in place for this URL and branch"}
 				return c.JSON(http.StatusConflict, reply)
 			}
@@ -156,7 +156,7 @@ func ReceiveRequest(c echo.Context) error {
 	}
 
 	// step 04: lets start this analysis!
-	log.Info(logActionReceiveRequest, logInfoAnalysis, 16, repository.Branch, repository.URL)
+	log.Info(logActionReceiveRequest, logInfoAnalysis, 16, repository.Branch, util.RedactURL(repository.URL))
 	go analysis.StartAnalysis(RID, repository)
 	reply := map[string]interface{}{"success": true, "error": ""}
 	return c.JSON(http.StatusCreated, reply)

--- a/api/routes/token.go
+++ b/api/routes/token.go
@@ -11,6 +11,7 @@ import (
 	"github.com/githubanotaai/huskyci-api/api/log"
 	"github.com/githubanotaai/huskyci-api/api/token"
 	"github.com/githubanotaai/huskyci-api/api/types"
+	"github.com/githubanotaai/huskyci-api/api/util"
 	"github.com/labstack/echo"
 )
 
@@ -34,7 +35,7 @@ func HandleToken(c echo.Context) error {
 		log.Error("HandleToken", "TOKEN", 1025, err)
 		return c.JSON(http.StatusBadRequest, map[string]interface{}{"success": false, "error": "invalid token JSON"})
 	}
-	log.Info("HandleToken", "TOKEN", 24, repoRequest.RepositoryURL)
+	log.Info("HandleToken", "TOKEN", 24, util.RedactURL(repoRequest.RepositoryURL))
 	accessToken, err := tokenHandler.GenerateAccessToken(repoRequest)
 	if err != nil {
 		log.Error("HandleToken ", "TOKEN", 1026, err)

--- a/api/securitytest/gosec_test.go
+++ b/api/securitytest/gosec_test.go
@@ -1,0 +1,129 @@
+// Copyright 2026 Globo.com authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package securitytest
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/githubanotaai/huskyci-api/api/types"
+)
+
+// Tier-4 parser regression template. Pattern to copy when adding tests for
+// the remaining per-tool analyzers (bandit, brakeman, npmaudit, spotbugs, ...).
+
+func loadGosecFixture(t *testing.T, name string) string {
+	t.Helper()
+	path := filepath.Join("testdata", "gosec", name)
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read fixture %s: %v", path, err)
+	}
+	return string(b)
+}
+
+// TestParseGosec_HighVulnerabilityFound asserts that a realistic gosec JSON
+// output with HIGH and MEDIUM findings is parsed and bucketed correctly into
+// scan.Vulnerabilities by severity.
+func TestParseGosec_HighVulnerabilityFound(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("analyzeGosec panicked on valid input: %v", r)
+		}
+	}()
+
+	scan := &SecTestScanInfo{
+		SecurityTestName: "gosec",
+		Container: types.Container{
+			COutput: loadGosecFixture(t, "high_vuln.json"),
+		},
+	}
+
+	if err := analyzeGosec(scan); err != nil {
+		t.Fatalf("analyzeGosec returned unexpected error: %v", err)
+	}
+
+	if len(scan.Vulnerabilities.HighVulns) < 1 {
+		t.Fatalf("expected at least 1 HighVuln, got %d", len(scan.Vulnerabilities.HighVulns))
+	}
+	if len(scan.Vulnerabilities.MediumVulns) < 1 {
+		t.Errorf("expected at least 1 MediumVuln, got %d", len(scan.Vulnerabilities.MediumVulns))
+	}
+
+	for i, v := range scan.Vulnerabilities.HighVulns {
+		if v.Severity == "" {
+			t.Errorf("HighVulns[%d].Severity is empty", i)
+		}
+		if v.Details == "" {
+			t.Errorf("HighVulns[%d].Details is empty", i)
+		}
+		if v.File == "" {
+			t.Errorf("HighVulns[%d].File is empty", i)
+		}
+	}
+}
+
+// TestParseGosec_CleanOutputProducesEmptyResults asserts that a clean gosec
+// run (no findings) yields no vulnerabilities and no error.
+func TestParseGosec_CleanOutputProducesEmptyResults(t *testing.T) {
+	t.Parallel()
+
+	scan := &SecTestScanInfo{
+		SecurityTestName: "gosec",
+		Container: types.Container{
+			COutput: loadGosecFixture(t, "no_vuln.json"),
+		},
+	}
+
+	if err := analyzeGosec(scan); err != nil {
+		t.Fatalf("analyzeGosec returned unexpected error on clean output: %v", err)
+	}
+	if len(scan.Vulnerabilities.HighVulns) != 0 {
+		t.Errorf("expected 0 HighVulns, got %d", len(scan.Vulnerabilities.HighVulns))
+	}
+	if len(scan.Vulnerabilities.MediumVulns) != 0 {
+		t.Errorf("expected 0 MediumVulns, got %d", len(scan.Vulnerabilities.MediumVulns))
+	}
+	if len(scan.Vulnerabilities.LowVulns) != 0 {
+		t.Errorf("expected 0 LowVulns, got %d", len(scan.Vulnerabilities.LowVulns))
+	}
+}
+
+// TestParseGosec_MalformedOutputDoesNotPanic catches gap #7 at the parser
+// level. If the parser panics on schema-misnamed input, the goroutine in
+// run.go (no defer recover() today) brings down the API process. The parser
+// must either return an empty result or return a non-nil error — but it must
+// not panic.
+func TestParseGosec_MalformedOutputDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("gosec parser panicked on malformed input: %v\n"+
+				"This is gap #7 — the parser must not panic; it must return an error or empty result", r)
+		}
+	}()
+
+	scan := &SecTestScanInfo{
+		SecurityTestName: "gosec",
+		Container: types.Container{
+			COutput: loadGosecFixture(t, "malformed.json"),
+		},
+	}
+
+	err := analyzeGosec(scan)
+	// Either outcome is acceptable: parser returns an error, OR parser succeeds
+	// with zero vulnerabilities because the misnamed "issues" field is ignored
+	// by encoding/json. What matters is that no panic escaped this goroutine.
+	total := len(scan.Vulnerabilities.HighVulns) +
+		len(scan.Vulnerabilities.MediumVulns) +
+		len(scan.Vulnerabilities.LowVulns)
+	if err == nil && total != 0 {
+		t.Errorf("expected zero vulnerabilities OR a non-nil error from malformed input; got %d vulns and nil error", total)
+	}
+}

--- a/api/securitytest/orchestration_test.go
+++ b/api/securitytest/orchestration_test.go
@@ -64,10 +64,10 @@ func TestStart_PassedWhenAllScannersPass(t *testing.T) {
 // for bug #8 (run.go:63-83 defer/return ordering): when any single scanner
 // returns CResult="failed", the final result must be "failed".
 //
-// Remove the Skip after the setToAnalysis/setFinalResult ordering bug is
-// resolved in run.go:65-81. When unskipped the test should pass green; if it
-// fails, the failure-propagation contract is broken and you should debug
-// setToAnalysis (run.go:243) and setFinalResult (run.go:324) before merging.
+// Remove the Skip after the setToAnalysis ordering bug is resolved in
+// run.go:65-81. When unskipped the test should pass green; if it fails, the
+// failure-propagation contract is broken and you should debug setToAnalysis
+// (run.go:279) before merging.
 func TestStart_FailedWhenAnyScannerFails(t *testing.T) {
 	tests := []types.SecurityTest{
 		{Name: "gitleaks"},

--- a/api/securitytest/orchestration_test.go
+++ b/api/securitytest/orchestration_test.go
@@ -69,8 +69,6 @@ func TestStart_PassedWhenAllScannersPass(t *testing.T) {
 // fails, the failure-propagation contract is broken and you should debug
 // setToAnalysis (run.go:243) and setFinalResult (run.go:324) before merging.
 func TestStart_FailedWhenAnyScannerFails(t *testing.T) {
-	t.Skip("Bug #8 — remove this Skip after setToAnalysis/setFinalResult order is fixed in run.go:65-81")
-
 	tests := []types.SecurityTest{
 		{Name: "gitleaks"},
 		{Name: "gitauthors"},
@@ -118,8 +116,6 @@ func TestStart_FailedWhenAnyScannerFails(t *testing.T) {
 //
 // Remove the Skip after the run.go:65-81 ordering issue is fixed.
 func TestStart_WarningWhenAllScannersWarn(t *testing.T) {
-	t.Skip("Bug #8 — remove this Skip after setToAnalysis/setFinalResult order is fixed in run.go:65-81")
-
 	tests := []types.SecurityTest{
 		{Name: "gitleaks"},
 		{Name: "gitauthors"},
@@ -165,8 +161,6 @@ func TestStart_WarningWhenAllScannersWarn(t *testing.T) {
 // run.go:100-124 and run.go:149-181. Until then, executing this test body
 // would crash the test binary itself — hence the Skip guards the harness.
 func TestStart_PanicInScannerDoesNotCrashAPI(t *testing.T) {
-	t.Skip("Gap #7 — remove this Skip after defer recover() is added to g.Go bodies in run.go:100-124 and run.go:149-181")
-
 	defer func() {
 		if r := recover(); r != nil {
 			t.Errorf("panic escaped Start(): %v — expected error return, not panic", r)
@@ -215,8 +209,6 @@ func TestStart_PanicInScannerDoesNotCrashAPI(t *testing.T) {
 // in run.go. Test asserts a max of 5 concurrent scanners; tune the limit to
 // match whatever value the fix configures.
 func TestStart_ConcurrencyIsLimited(t *testing.T) {
-	t.Skip("Gap #3 — remove this Skip after errgroup.SetLimit is added in run.go")
-
 	const totalScanners = 20
 	const maxAllowed = int32(5)
 

--- a/api/securitytest/orchestration_test.go
+++ b/api/securitytest/orchestration_test.go
@@ -1,0 +1,283 @@
+// Copyright 2026 Globo.com authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package securitytest
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/githubanotaai/huskyci-api/api/types"
+)
+
+// Tier-1 orchestration safety net. These tests pin down the contract of
+// RunAllInfo.Start() so future fixes to run.go (bug #8 finalization order,
+// gap #7 panic recovery, gap #3 concurrency limit) cannot silently regress.
+//
+// Tests use the existing mockRunner from runner.go so no real DB or container
+// runtime is involved.
+
+// TestStart_PassedWhenAllScannersPass is the baseline. Multiple scanners all
+// report CResult="passed" — Start() must return nil and FinalResult must be
+// "passed". This test must remain green on the current code; if it ever fails
+// the orchestration core has regressed.
+func TestStart_PassedWhenAllScannersPass(t *testing.T) {
+	tests := []types.SecurityTest{
+		{Name: "gitleaks"},
+		{Name: "gitauthors"},
+		{Name: "wizcli_secrets"},
+	}
+
+	runner := &mockRunner{
+		genericTests: tests,
+		newScanFunc: func(RID, URL, branch, name string, le map[string]bool, cf, dh string) (*SecTestScanInfo, error) {
+			return &SecTestScanInfo{
+				RID:              RID,
+				SecurityTestName: name,
+				Container: types.Container{
+					CID:     "cid-" + name,
+					CResult: "passed",
+					CStatus: "finished",
+				},
+			}, nil
+		},
+		startScanFunc: func(scan *SecTestScanInfo) error { return nil },
+	}
+
+	results := &RunAllInfo{runner: runner}
+	enryScan := SecTestScanInfo{
+		RID: "baseline-rid", URL: "https://example.com/repo", Branch: "main",
+	}
+
+	if err := results.Start(enryScan); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if results.FinalResult != "passed" {
+		t.Errorf("expected FinalResult=%q, got %q", "passed", results.FinalResult)
+	}
+}
+
+// TestStart_FailedWhenAnyScannerFails asserts the desired post-fix behavior
+// for bug #8 (run.go:63-83 defer/return ordering): when any single scanner
+// returns CResult="failed", the final result must be "failed".
+//
+// Remove the Skip after the setToAnalysis/setFinalResult ordering bug is
+// resolved in run.go:65-81. When unskipped the test should pass green; if it
+// fails, the failure-propagation contract is broken and you should debug
+// setToAnalysis (run.go:243) and setFinalResult (run.go:324) before merging.
+func TestStart_FailedWhenAnyScannerFails(t *testing.T) {
+	t.Skip("Bug #8 — remove this Skip after setToAnalysis/setFinalResult order is fixed in run.go:65-81")
+
+	tests := []types.SecurityTest{
+		{Name: "gitleaks"},
+		{Name: "gitauthors"},
+		{Name: "wizcli_secrets"},
+	}
+
+	results := map[string]string{
+		"gitleaks":       "failed",
+		"gitauthors":     "passed",
+		"wizcli_secrets": "passed",
+	}
+
+	runner := &mockRunner{
+		genericTests: tests,
+		newScanFunc: func(RID, URL, branch, name string, le map[string]bool, cf, dh string) (*SecTestScanInfo, error) {
+			return &SecTestScanInfo{
+				RID:              RID,
+				SecurityTestName: name,
+				Container: types.Container{
+					CID:     "cid-" + name,
+					CResult: results[name],
+					CStatus: "finished",
+				},
+			}, nil
+		},
+		startScanFunc: func(scan *SecTestScanInfo) error { return nil },
+	}
+
+	run := &RunAllInfo{runner: runner}
+	enryScan := SecTestScanInfo{
+		RID: "failed-rid", URL: "https://example.com/repo", Branch: "main",
+	}
+
+	if err := run.Start(enryScan); err != nil {
+		t.Fatalf("Start returned unexpected error: %v", err)
+	}
+	if run.FinalResult != "failed" {
+		t.Errorf("expected FinalResult=%q with one failed scanner, got %q", "failed", run.FinalResult)
+	}
+}
+
+// TestStart_WarningWhenAllScannersWarn asserts the desired post-fix behavior
+// for the warning-propagation half of bug #8: when all scanners report
+// "warning" and none fail, the final result must be "warning", not "passed".
+//
+// Remove the Skip after the run.go:65-81 ordering issue is fixed.
+func TestStart_WarningWhenAllScannersWarn(t *testing.T) {
+	t.Skip("Bug #8 — remove this Skip after setToAnalysis/setFinalResult order is fixed in run.go:65-81")
+
+	tests := []types.SecurityTest{
+		{Name: "gitleaks"},
+		{Name: "gitauthors"},
+		{Name: "wizcli_secrets"},
+	}
+
+	runner := &mockRunner{
+		genericTests: tests,
+		newScanFunc: func(RID, URL, branch, name string, le map[string]bool, cf, dh string) (*SecTestScanInfo, error) {
+			return &SecTestScanInfo{
+				RID:              RID,
+				SecurityTestName: name,
+				Container: types.Container{
+					CID:          "cid-" + name,
+					CResult:      "warning",
+					CStatus:      "finished",
+					SecurityTest: types.SecurityTest{Name: name, Language: "Generic"},
+				},
+			}, nil
+		},
+		startScanFunc: func(scan *SecTestScanInfo) error { return nil },
+	}
+
+	run := &RunAllInfo{runner: runner}
+	enryScan := SecTestScanInfo{
+		RID: "warning-rid", URL: "https://example.com/repo", Branch: "main",
+	}
+
+	if err := run.Start(enryScan); err != nil {
+		t.Fatalf("Start returned unexpected error: %v", err)
+	}
+	if run.FinalResult != "warning" {
+		t.Errorf("expected FinalResult=%q with all warning scanners, got %q", "warning", run.FinalResult)
+	}
+}
+
+// TestStart_PanicInScannerDoesNotCrashAPI documents gap #7. The goroutines
+// spawned inside runGenericScans (run.go:100) and runLanguageScans (run.go:149)
+// have no defer recover(), so a panic inside any scanner brings down the API.
+// The desired post-fix behavior: panics are recovered and surfaced as errors.
+//
+// Remove the Skip after defer recover() is added to the g.Go bodies in
+// run.go:100-124 and run.go:149-181. Until then, executing this test body
+// would crash the test binary itself — hence the Skip guards the harness.
+func TestStart_PanicInScannerDoesNotCrashAPI(t *testing.T) {
+	t.Skip("Gap #7 — remove this Skip after defer recover() is added to g.Go bodies in run.go:100-124 and run.go:149-181")
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("panic escaped Start(): %v — expected error return, not panic", r)
+		}
+	}()
+
+	tests := []types.SecurityTest{
+		{Name: "gitleaks"},
+		{Name: "gitauthors"},
+	}
+
+	runner := &mockRunner{
+		genericTests: tests,
+		newScanFunc: func(RID, URL, branch, name string, le map[string]bool, cf, dh string) (*SecTestScanInfo, error) {
+			return &SecTestScanInfo{
+				RID:              RID,
+				SecurityTestName: name,
+				Container:        types.Container{CID: "cid-" + name, CResult: "passed"},
+			}, nil
+		},
+		startScanFunc: func(scan *SecTestScanInfo) error {
+			if scan.SecurityTestName == "gitleaks" {
+				panic("simulated malformed output from gitleaks parser")
+			}
+			return nil
+		},
+	}
+
+	run := &RunAllInfo{runner: runner}
+	enryScan := SecTestScanInfo{
+		RID: "panic-rid", URL: "https://example.com/repo", Branch: "main",
+	}
+
+	err := run.Start(enryScan)
+	if err == nil {
+		t.Error("expected non-nil error after scanner panic was recovered, got nil")
+	}
+}
+
+// TestStart_ConcurrencyIsLimited documents gap #3. Today errgroup.Group is
+// used without SetLimit, so K languages × N scanners all run concurrently
+// with no bound. The desired post-fix behavior: peak in-flight scanners
+// never exceeds a small configured limit.
+//
+// Remove the Skip after errgroup.SetLimit (or equivalent semaphore) is added
+// in run.go. Test asserts a max of 5 concurrent scanners; tune the limit to
+// match whatever value the fix configures.
+func TestStart_ConcurrencyIsLimited(t *testing.T) {
+	t.Skip("Gap #3 — remove this Skip after errgroup.SetLimit is added in run.go")
+
+	const totalScanners = 20
+	const maxAllowed = int32(5)
+
+	tests := make([]types.SecurityTest, 0, totalScanners)
+	for i := 0; i < totalScanners; i++ {
+		tests = append(tests, types.SecurityTest{Name: "scanner_" + itoa(i)})
+	}
+
+	var inFlight atomic.Int32
+	var peak atomic.Int32
+	var mu sync.Mutex
+
+	runner := &mockRunner{
+		genericTests: tests,
+		newScanFunc: func(RID, URL, branch, name string, le map[string]bool, cf, dh string) (*SecTestScanInfo, error) {
+			return &SecTestScanInfo{
+				RID:              RID,
+				SecurityTestName: name,
+				Container:        types.Container{CID: "cid-" + name, CResult: "passed"},
+			}, nil
+		},
+		startScanFunc: func(scan *SecTestScanInfo) error {
+			current := inFlight.Add(1)
+			mu.Lock()
+			if current > peak.Load() {
+				peak.Store(current)
+			}
+			mu.Unlock()
+			time.Sleep(50 * time.Millisecond)
+			inFlight.Add(-1)
+			return nil
+		},
+	}
+
+	run := &RunAllInfo{runner: runner}
+	enryScan := SecTestScanInfo{
+		RID: "concurrency-rid", URL: "https://example.com/repo", Branch: "main",
+	}
+
+	if err := run.Start(enryScan); err != nil {
+		t.Fatalf("Start returned unexpected error: %v", err)
+	}
+	if got := peak.Load(); got > maxAllowed {
+		t.Errorf("peak concurrent scanners = %d, want <= %d (concurrency limit not enforced)", got, maxAllowed)
+	}
+	if len(run.Containers) != totalScanners {
+		t.Errorf("expected %d containers to complete, got %d", totalScanners, len(run.Containers))
+	}
+}
+
+// itoa avoids importing strconv just to label test scanners.
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	pos := len(buf)
+	for i > 0 {
+		pos--
+		buf[pos] = byte('0' + i%10)
+		i /= 10
+	}
+	return string(buf[pos:])
+}

--- a/api/securitytest/run.go
+++ b/api/securitytest/run.go
@@ -2,7 +2,9 @@ package securitytest
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -14,8 +16,8 @@ import (
 
 // RunAllInfo store all scans results of an Analysis
 type RunAllInfo struct {
-	runner         scanRunner        `json:"-" bson:"-"`
-	mu             sync.Mutex        `json:"-" bson:"-"`
+	runner         scanRunner `json:"-" bson:"-"`
+	mu             sync.Mutex `json:"-" bson:"-"`
 	RID            string
 	Status         string
 	Containers     []types.Container
@@ -45,9 +47,9 @@ const tfsec = "tfsec"
 const securitycodescan = "securitycodescan"
 const (
 	wizcliSecrets = "wizcli_secrets"
-	wizcliIac      = "wizcli_iac"
-	wizcliSast     = "wizcli_sast"
-	wizcliVulns    = "wizcli_vulns"
+	wizcliIac     = "wizcli_iac"
+	wizcliSast    = "wizcli_sast"
+	wizcliVulns   = "wizcli_vulns"
 )
 
 // isTestDisabled checks if a security test is disabled via environment variable.
@@ -78,12 +80,12 @@ func (results *RunAllInfo) Start(enryScan SecTestScanInfo) error {
 		return err
 	}
 
-	results.setFinalResult()
 	return nil
 }
 
 func (results *RunAllInfo) runGenericScans(ctx context.Context, enryScan SecTestScanInfo) error {
 	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(maxConcurrentScanners())
 	runner := results.getRunner()
 
 	genericTests, err := runner.listGenericTests()
@@ -97,7 +99,12 @@ func (results *RunAllInfo) runGenericScans(ctx context.Context, enryScan SecTest
 			log.Info("runGenericScans", "SECURITYTEST", 0, "Skipping disabled test: "+testName)
 			continue
 		}
-		g.Go(func() error {
+		g.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = scannerPanicError{testName: testName, value: r}
+				}
+			}()
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
@@ -129,6 +136,7 @@ func (results *RunAllInfo) runGenericScans(ctx context.Context, enryScan SecTest
 
 func (results *RunAllInfo) runLanguageScans(ctx context.Context, enryScan SecTestScanInfo) error {
 	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(maxConcurrentScanners())
 	runner := results.getRunner()
 
 	languageTests := []types.SecurityTest{}
@@ -146,7 +154,12 @@ func (results *RunAllInfo) runLanguageScans(ctx context.Context, enryScan SecTes
 			log.Info("runLanguageScans", "SECURITYTEST", 0, "Skipping disabled test: "+testName)
 			continue
 		}
-		g.Go(func() error {
+		g.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = scannerPanicError{testName: testName, value: r}
+				}
+			}()
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
@@ -182,6 +195,29 @@ func (results *RunAllInfo) runLanguageScans(ctx context.Context, enryScan SecTes
 	}
 
 	return g.Wait()
+}
+
+const defaultMaxConcurrentScanners = 5
+
+type scannerPanicError struct {
+	testName string
+	value    interface{}
+}
+
+func (e scannerPanicError) Error() string {
+	return fmt.Sprintf("scanner %s panicked: %v", e.testName, e.value)
+}
+
+func maxConcurrentScanners() int {
+	value := strings.TrimSpace(os.Getenv("HUSKYCI_MAX_CONCURRENT_SCANNERS"))
+	if value == "" {
+		return defaultMaxConcurrentScanners
+	}
+	limit, err := strconv.Atoi(value)
+	if err != nil || limit <= 0 {
+		return defaultMaxConcurrentScanners
+	}
+	return limit
 }
 
 // vulnOutput maps a security test name to its corresponding HuskyCISecurityTestOutput pointer.

--- a/api/securitytest/run.go
+++ b/api/securitytest/run.go
@@ -357,24 +357,6 @@ func (results *RunAllInfo) coalesceJsLockfileErrors() {
 	)
 }
 
-func (results *RunAllInfo) setFinalResult() {
-	// Logic to determine the final result based on scan results.
-	// For example, if all scans passed, set FinalResult to "passed".
-	// If any critical scan failed, set FinalResult to "failed".
-	passed := true
-	for _, container := range results.Containers {
-		if container.CResult == "failed" {
-			passed = false
-			break
-		}
-	}
-	if passed {
-		results.FinalResult = "passed"
-	} else {
-		results.FinalResult = "failed"
-	}
-}
-
 func (results *RunAllInfo) getRunner() scanRunner {
 	if results.runner != nil {
 		return results.runner

--- a/api/securitytest/securitytest.go
+++ b/api/securitytest/securitytest.go
@@ -162,7 +162,7 @@ func (scanInfo *SecTestScanInfo) analyze() error {
 		} else {
 			errorMsg = errors.New("error cloning")
 		}
-		log.Error("analyze", "SECURITYTEST", 1031, scanInfo.URL, scanInfo.Branch, errorMsg)
+		log.Error("analyze", "SECURITYTEST", 1031, util.RedactURL(scanInfo.URL), scanInfo.Branch, errorMsg)
 		scanInfo.ErrorFound = errorMsg
 		return errorMsg
 	}

--- a/api/securitytest/testdata/gosec/high_vuln.json
+++ b/api/securitytest/testdata/gosec/high_vuln.json
@@ -1,0 +1,28 @@
+{
+  "Issues": [
+    {
+      "severity": "HIGH",
+      "confidence": "HIGH",
+      "rule_id": "G401",
+      "details": "Use of weak cryptographic primitive",
+      "file": "/src/main.go",
+      "code": "md5.New()",
+      "line": "12"
+    },
+    {
+      "severity": "MEDIUM",
+      "confidence": "MEDIUM",
+      "rule_id": "G304",
+      "details": "File path provided as taint input",
+      "file": "/src/handler.go",
+      "code": "os.Open(userInput)",
+      "line": "47"
+    }
+  ],
+  "Stats": {
+    "files": 2,
+    "lines": 120,
+    "nosec": 0,
+    "found": 2
+  }
+}

--- a/api/securitytest/testdata/gosec/malformed.json
+++ b/api/securitytest/testdata/gosec/malformed.json
@@ -1,0 +1,4 @@
+{
+  "issues": null,
+  "unexpected_field": true
+}

--- a/api/securitytest/testdata/gosec/no_vuln.json
+++ b/api/securitytest/testdata/gosec/no_vuln.json
@@ -1,0 +1,9 @@
+{
+  "Issues": [],
+  "Stats": {
+    "files": 3,
+    "lines": 200,
+    "nosec": 0,
+    "found": 0
+  }
+}

--- a/api/securitytest/wizcli.go
+++ b/api/securitytest/wizcli.go
@@ -12,6 +12,10 @@ import (
 	"github.com/githubanotaai/huskyci-api/api/util"
 )
 
+const maxWizCLIJSONBytes = 1000000
+
+var errWizCLIOutputTooLarge = errors.New("wizcli json output exceeds size limit")
+
 // wizCLIReport models the subset of `wizcli scan dir --stdout=json` output that
 // huskyCI surfaces as findings. Unrelated metadata (analytics, sbomOutput,
 // hostConfiguration, ...) is intentionally ignored.
@@ -21,16 +25,16 @@ type wizCLIReport struct {
 		Verdict string `json:"verdict"`
 	} `json:"status"`
 	Result struct {
-		Libraries             []wizPackageWithVulns  `json:"libraries"`
-		OSPackages            []wizPackageWithVulns  `json:"osPackages"`
-		Secrets               []wizSecretFinding     `json:"secrets"`
-		DataFindings          []wizDataFinding       `json:"dataFindings"`
-		EndOfLifeTechnologies []wizEndOfLifeFinding     `json:"endOfLifeTechnologies"`
-		Iac                 *wizIacSastResult      `json:"iac"`
-		Sast                *wizIacSastResult      `json:"sast"`
-		Malwares            []wizMalwareFinding       `json:"malwares"`
-		AIModels            []wizAIModelFinding       `json:"aiModels"`
-		SoftwareSupplyChain []wizSupplyChainFinding   `json:"softwareSupplyChain"`
+		Libraries             []wizPackageWithVulns   `json:"libraries"`
+		OSPackages            []wizPackageWithVulns   `json:"osPackages"`
+		Secrets               []wizSecretFinding      `json:"secrets"`
+		DataFindings          []wizDataFinding        `json:"dataFindings"`
+		EndOfLifeTechnologies []wizEndOfLifeFinding   `json:"endOfLifeTechnologies"`
+		Iac                   *wizIacSastResult       `json:"iac"`
+		Sast                  *wizIacSastResult       `json:"sast"`
+		Malwares              []wizMalwareFinding     `json:"malwares"`
+		AIModels              []wizAIModelFinding     `json:"aiModels"`
+		SoftwareSupplyChain   []wizSupplyChainFinding `json:"softwareSupplyChain"`
 	} `json:"result"`
 }
 
@@ -78,10 +82,10 @@ type wizIacSastResult struct {
 }
 
 type wizRuleMatch struct {
-	Rule               wizRuleRef      `json:"rule"`
-	Severity           string          `json:"severity"`
-	FailedResourceCount int            `json:"failedResourceCount"`
-	Matches            []wizMatchEntry `json:"matches"`
+	Rule                wizRuleRef      `json:"rule"`
+	Severity            string          `json:"severity"`
+	FailedResourceCount int             `json:"failedResourceCount"`
+	Matches             []wizMatchEntry `json:"matches"`
 }
 
 type wizRuleRef struct {
@@ -90,13 +94,13 @@ type wizRuleRef struct {
 }
 
 type wizMatchEntry struct {
-	ResourceName           string `json:"resourceName"`
-	FileName               string `json:"fileName"`
-	LineNumber             int    `json:"lineNumber"`
-	MatchContent           string `json:"matchContent"`
-	Expected               string `json:"expected"`
-	Found                  string `json:"found"`
-	FileType               string `json:"fileType"`
+	ResourceName            string `json:"resourceName"`
+	FileName                string `json:"fileName"`
+	LineNumber              int    `json:"lineNumber"`
+	MatchContent            string `json:"matchContent"`
+	Expected                string `json:"expected"`
+	Found                   string `json:"found"`
+	FileType                string `json:"fileType"`
 	RemediationInstructions string `json:"remediationInstructions"`
 }
 
@@ -165,25 +169,25 @@ func analyzeWizCLI(scanInfo *SecTestScanInfo) error {
 // manifestFileTypes maps manifest file names/basenames to their language ecosystem.
 var manifestFileTypes = map[string]string{
 	// Python
-	"requirements.txt":    "python",
-	"requirements":        "python", // prefix match for requirements-*.txt
-	"pyproject.toml":      "python",
-	"setup.py":            "python",
-	"Pipfile":             "python",
-	"Pipfile.lock":        "python",
+	"requirements.txt": "python",
+	"requirements":     "python", // prefix match for requirements-*.txt
+	"pyproject.toml":   "python",
+	"setup.py":         "python",
+	"Pipfile":          "python",
+	"Pipfile.lock":     "python",
 	// Node.js
-	"package-lock.json": "node",
-	"package.json":       "node",
-	"yarn.lock":          "node",
+	"package-lock.json":   "node",
+	"package.json":        "node",
+	"yarn.lock":           "node",
 	"npm-shrinkwrap.json": "node",
-	"pnpm-lock.yaml":    "node",
+	"pnpm-lock.yaml":      "node",
 	// Go
 	"go.mod": "go",
 	"go.sum": "go",
 	// Java
-	"pom.xml":           "java",
-	"build.gradle":      "java",
-	"build.gradle.kts":  "java",
+	"pom.xml":          "java",
+	"build.gradle":     "java",
+	"build.gradle.kts": "java",
 	// Ruby
 	"Gemfile":      "ruby",
 	"Gemfile.lock": "ruby",
@@ -191,8 +195,8 @@ var manifestFileTypes = map[string]string{
 	"composer.json": "php",
 	"composer.lock": "php",
 	// .NET
-	"packages.config":  "dotnet",
-	"project.json":     "dotnet",
+	"packages.config":   "dotnet",
+	"project.json":      "dotnet",
 	"project.lock.json": "dotnet",
 	// Rust
 	"Cargo.toml": "rust",
@@ -314,10 +318,10 @@ func validateSonarQubeFilePath(filePath string) error {
 
 // sonarQubeExternalIssue represents a single external issue for SonarQube import.
 type sonarQubeExternalIssue struct {
-	EngineID       string `json:"engineId"`
-	RuleID         string `json:"ruleId"`
-	Severity       string `json:"severity,omitempty"`
-	Type           string `json:"type,omitempty"`
+	EngineID        string `json:"engineId"`
+	RuleID          string `json:"ruleId"`
+	Severity        string `json:"severity,omitempty"`
+	Type            string `json:"type,omitempty"`
 	PrimaryLocation struct {
 		Message  string `json:"message"`
 		FilePath string `json:"filePath"`
@@ -377,6 +381,10 @@ func generateSonarQubeExternalIssue(vuln types.HuskyCIVulnerability) sonarQubeEx
 // into HuskyCIVulnerability entries, covering CVEs (libraries, OS packages),
 // secrets, data findings, and end-of-life technologies.
 func parseWizCLIJSON(output string) ([]types.HuskyCIVulnerability, error) {
+	if len(output) > maxWizCLIJSONBytes {
+		return nil, fmt.Errorf("%w: got %d bytes, limit %d bytes", errWizCLIOutputTooLarge, len(output), maxWizCLIJSONBytes)
+	}
+
 	var report wizCLIReport
 	if err := json.Unmarshal([]byte(output), &report); err != nil {
 		return nil, err

--- a/api/securitytest/wizcli_test.go
+++ b/api/securitytest/wizcli_test.go
@@ -1,6 +1,7 @@
 package securitytest
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -43,6 +44,13 @@ func TestParseWizCLIJSON_InvalidJSON(t *testing.T) {
 	_, err := parseWizCLIJSON("not json")
 	if err == nil {
 		t.Error("expected error parsing invalid JSON, got nil")
+	}
+}
+
+func TestParseWizCLIJSON_OversizedOutput(t *testing.T) {
+	_, err := parseWizCLIJSON(strings.Repeat("x", maxWizCLIJSONBytes+1))
+	if !errors.Is(err, errWizCLIOutputTooLarge) {
+		t.Fatalf("expected errWizCLIOutputTooLarge, got %v", err)
 	}
 }
 
@@ -804,7 +812,7 @@ func TestGenerateSonarQubeExternalIssue(t *testing.T) {
 				Severity:     "HIGH",
 				File:         "requirements.txt:pytest:7.4.3",
 				Line:         "5",
-				Details:       "CVE-2023-XXXX (fixed: 7.4.4)",
+				Details:      "CVE-2023-XXXX (fixed: 7.4.4)",
 				SecurityTool: "WizCLI",
 			},
 		},
@@ -815,7 +823,7 @@ func TestGenerateSonarQubeExternalIssue(t *testing.T) {
 				Severity:     "CRITICAL",
 				File:         "app/db/queries.py",
 				Line:         "42",
-				Details:       "Potential SQL injection in user input",
+				Details:      "Potential SQL injection in user input",
 				SecurityTool: "WizCLI",
 			},
 		},

--- a/api/token/token.go
+++ b/api/token/token.go
@@ -6,6 +6,7 @@ package token
 
 import (
 	"crypto/sha256"
+	"crypto/subtle"
 	"errors"
 	"fmt"
 	"strings"
@@ -89,7 +90,7 @@ func (tH *THandler) ValidateRandomData(rdata, hashdata, salt string) error {
 	keyLength := tH.HashGen.GetKeyLength()
 	iterations := tH.HashGen.GetIterations()
 	hashval := tH.HashGen.GenHashValue([]byte(rdata), bSalt, iterations, keyLength, h)
-	if hashval != hashdata {
+	if subtle.ConstantTimeCompare([]byte(hashval), []byte(hashdata)) != 1 {
 		return errors.New("Hash value from random data is different")
 	}
 	return nil

--- a/api/util/util.go
+++ b/api/util/util.go
@@ -6,7 +6,10 @@ package util
 
 import (
 	"bufio"
+	"io"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"regexp"
 	"strconv"
@@ -30,6 +33,23 @@ const (
 
 const logInfoAnalysis = "ANALYSIS"
 const logActionReceiveRequest = "ReceiveRequest"
+
+var validRepoURL = regexp.MustCompile(`((git|ssh|http(s)?)|((git@|gitlab@)[\w\.]+))(:(//)?)([\w\.@\:/\-~]+)(\.git)(/)?`)
+
+const MaxScannerOutputBytes = 100 * 1024 * 1024
+
+var ErrScannerOutputTooLarge = errors.New("scanner output exceeds size limit")
+
+func ReadBoundedScannerOutput(reader io.Reader) (string, error) {
+	body, err := io.ReadAll(io.LimitReader(reader, MaxScannerOutputBytes+1))
+	if err != nil {
+		return "", err
+	}
+	if len(body) > MaxScannerOutputBytes {
+		return "", fmt.Errorf("%w: limit %d bytes", ErrScannerOutputTooLarge, MaxScannerOutputBytes)
+	}
+	return string(body), nil
+}
 
 // HandleCmd will extract %GIT_REPO%, %GIT_BRANCH% from cmd and replace it with the proper repository URL.
 // Also replaces %WIZ_CLIENT_ID% and %WIZ_CLIENT_SECRET% with values from environment variables.
@@ -140,7 +160,33 @@ func RemoveDuplicates(s []string) []string {
 
 // HandleScanError show the right error when json is not expected as output of scan
 func HandleScanError(containerOutput string, otherErr error) error {
-	return fmt.Errorf("%s\nError from top: %v", containerOutput, otherErr)
+	return fmt.Errorf("%s\nError from top: %v", boundedScannerOutput(containerOutput), otherErr)
+}
+
+func boundedScannerOutput(output string) string {
+	const edgeSize = 512
+	if len(output) <= edgeSize*2 {
+		return output
+	}
+	prefix := output[:edgeSize]
+	suffix := output[len(output)-edgeSize:]
+	return fmt.Sprintf("%s\n... scanner output truncated, total bytes: %d ...\n%s", prefix, len(output), suffix)
+}
+
+// RedactURL removes URL userinfo before values are written to logs.
+func RedactURL(raw string) string {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		if strings.HasPrefix(raw, "git@") || strings.HasPrefix(raw, "gitlab@") {
+			return raw
+		}
+		if at := strings.LastIndex(raw, "@"); at > 0 {
+			return "[redacted]" + raw[at:]
+		}
+		return "[unparseable]"
+	}
+	parsed.User = nil
+	return parsed.String()
 }
 
 // CheckValidInput checks if an user's input is "malicious" or not
@@ -149,7 +195,7 @@ func CheckValidInput(repository types.Repository, c echo.Context) (string, error
 	sanitiziedURL, err := CheckMaliciousRepoURL(repository.URL)
 	if err != nil {
 		if sanitiziedURL == "" {
-			log.Error(logActionReceiveRequest, logInfoAnalysis, 1016, repository.URL)
+			log.Error(logActionReceiveRequest, logInfoAnalysis, 1016, RedactURL(repository.URL))
 			reply := map[string]interface{}{"success": false, "error": "invalid repository URL"}
 			return "", c.JSON(http.StatusBadRequest, reply)
 		}
@@ -167,17 +213,43 @@ func CheckValidInput(repository types.Repository, c echo.Context) (string, error
 
 // CheckMaliciousRepoURL verifies if a given URL is a git repository and returns the sanitizied string and its error
 func CheckMaliciousRepoURL(repositoryURL string) (string, error) {
-	regexpGit := `((git|ssh|http(s)?)|((git@|gitlab@)[\w\.]+))(:(//)?)([\w\.@\:/\-~]+)(\.git)(/)?`
-	r := regexp.MustCompile(regexpGit)
-	valid, err := regexp.MatchString(regexpGit, repositoryURL)
-	if err != nil {
-		return "matchStringError", err
-	}
-	if !valid {
+	if !validRepoURL.MatchString(repositoryURL) {
 		errorMsg := fmt.Sprintf("Invalid URL format: %s", repositoryURL)
 		return "", errors.New(errorMsg)
 	}
-	return r.FindString(repositoryURL), nil
+	sanitized := validRepoURL.FindString(repositoryURL)
+	if strings.HasPrefix(sanitized, "git@") || strings.HasPrefix(sanitized, "gitlab@") {
+		return sanitized, nil
+	}
+
+	parsed, err := url.Parse(sanitized)
+	if err != nil {
+		return "", err
+	}
+	switch parsed.Scheme {
+	case "git", "http", "https", "ssh":
+	default:
+		return "", fmt.Errorf("invalid repository URL scheme: %s", parsed.Scheme)
+	}
+	if parsed.User != nil {
+		return "", errors.New("repository URL must not contain credentials")
+	}
+	if isUnsafeRepoHost(parsed.Hostname()) {
+		return "", errors.New("repository URL points to a blocked host")
+	}
+	return sanitized, nil
+}
+
+func isUnsafeRepoHost(host string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	if host == "" || host == "localhost" || strings.HasSuffix(host, ".localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	return ip.IsPrivate() || ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified()
 }
 
 // CheckMaliciousRepoBranch verifies if a given branch is "malicious" or not
@@ -189,7 +261,7 @@ func CheckMaliciousRepoBranch(repositoryBranch string, c echo.Context) error {
 		reply := map[string]interface{}{"success": false, "error": "internal error"}
 		return c.JSON(http.StatusInternalServerError, reply)
 	}
-	if !valid {
+	if !valid || hasUnsafePathSegment(repositoryBranch) {
 		log.Error(logActionReceiveRequest, logInfoAnalysis, 1017, repositoryBranch)
 		reply := map[string]interface{}{"success": false, "error": "invalid repository branch"}
 		return c.JSON(http.StatusBadRequest, reply)
@@ -212,10 +284,35 @@ func CheckMaliciousChangedFiles(changedFiles string) error {
 	if err != nil {
 		return err
 	}
-	if !valid {
+	if !valid || hasUnsafeChangedFilePath(changedFiles) {
 		return errors.New("invalid changed files: contains forbidden characters")
 	}
 	return nil
+}
+
+func hasUnsafeChangedFilePath(changedFiles string) bool {
+	for _, file := range strings.Split(changedFiles, "\n") {
+		file = strings.TrimSpace(file)
+		if file == "" {
+			continue
+		}
+		if strings.HasPrefix(file, "/") || strings.HasPrefix(file, "\\") || hasUnsafePathSegment(file) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasUnsafePathSegment(value string) bool {
+	parts := strings.FieldsFunc(value, func(r rune) bool {
+		return r == '/' || r == '\\'
+	})
+	for _, part := range parts {
+		if part == ".." {
+			return true
+		}
+	}
+	return false
 }
 
 // CheckMaliciousRID verifies if a given RID is "malicious" or not

--- a/api/util/util_test.go
+++ b/api/util/util_test.go
@@ -5,10 +5,12 @@
 package util_test
 
 import (
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 
 	"github.com/githubanotaai/huskyci-api/api/log"
 	"github.com/githubanotaai/huskyci-api/api/types"
@@ -191,6 +193,43 @@ Line4`
 		Context("When rawSliceString is empty", func() {
 			It("Should return an empty slice of string.", func() {
 				Expect(util.GetAllLinesButLast("")).To(Equal([]string{}))
+			})
+		})
+	})
+
+	Describe("HandleScanError", func() {
+		Context("When scanner output is large", func() {
+			It("Should include bounded output and total byte count", func() {
+				err := util.HandleScanError(strings.Repeat("a", 2000), errors.New("invalid json"))
+				Expect(err.Error()).To(ContainSubstring("scanner output truncated"))
+				Expect(err.Error()).To(ContainSubstring("total bytes: 2000"))
+				Expect(len(err.Error())).To(BeNumerically("<", 1300))
+			})
+		})
+	})
+
+	Describe("ReadBoundedScannerOutput", func() {
+		Context("When scanner output is below the limit", func() {
+			It("Should return the full output", func() {
+				out, err := util.ReadBoundedScannerOutput(strings.NewReader("scanner-json"))
+				Expect(err).To(BeNil())
+				Expect(out).To(Equal("scanner-json"))
+			})
+		})
+	})
+
+	Describe("RedactURL", func() {
+		Context("When URL contains userinfo", func() {
+			It("Should remove credentials", func() {
+				raw := "https://user:token@github.com/org/repo.git"
+				Expect(util.RedactURL(raw)).To(Equal("https://github.com/org/repo.git"))
+			})
+		})
+
+		Context("When URL has no userinfo", func() {
+			It("Should leave it unchanged", func() {
+				raw := "git@github.com:org/repo.git"
+				Expect(util.RedactURL(raw)).To(Equal(raw))
 			})
 		})
 	})

--- a/api/util/validation_test.go
+++ b/api/util/validation_test.go
@@ -24,9 +24,7 @@ func init() {
 }
 
 // Tier-3 input-validation safety net. Pins the contract of the three malicious
-// input validators so SSRF/path-traversal hardening (gap #10) can land safely.
-// Table rows that test desired-but-not-yet-implemented blocks are nested under
-// t.Skip subtests so the parent test stays green on current code.
+// input validators so SSRF/path-traversal hardening (gap #10) stays covered.
 
 // TestCheckMaliciousRepoURL asserts the URL validator's contract for both
 // (a) inputs that must remain accepted regardless of future hardening, and
@@ -57,8 +55,6 @@ func TestCheckMaliciousRepoURL(t *testing.T) {
 	}
 
 	t.Run("gap_10_ssrf_targets_not_yet_blocked", func(t *testing.T) {
-		t.Skip("Gap #10 — remove this Skip after CheckMaliciousRepoURL blocks RFC1918, link-local, loopback, file://, and credentials-in-URL")
-
 		ssrfCases := []struct {
 			name        string
 			input       string
@@ -132,8 +128,6 @@ func TestCheckMaliciousBranch(t *testing.T) {
 	}
 
 	t.Run("gap_path_traversal_not_yet_blocked", func(t *testing.T) {
-		t.Skip("Branch path-traversal gap — remove this Skip after CheckMaliciousRepoBranch (util.go:184) rejects '..' segments")
-
 		traversal := []struct {
 			name        string
 			input       string
@@ -186,8 +180,6 @@ func TestCheckMaliciousChangedFiles(t *testing.T) {
 	}
 
 	t.Run("gap_path_and_absolute_not_yet_blocked", func(t *testing.T) {
-		t.Skip("Changed-files path/absolute gap — remove this Skip after CheckMaliciousChangedFiles (util.go:204) rejects '..' and leading '/'")
-
 		extra := []struct {
 			name        string
 			input       string

--- a/api/util/validation_test.go
+++ b/api/util/validation_test.go
@@ -1,0 +1,211 @@
+// Copyright 2026 Globo.com authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package util_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo"
+
+	"github.com/githubanotaai/huskyci-api/api/log"
+	"github.com/githubanotaai/huskyci-api/api/util"
+)
+
+// log.Logger is a package-level variable that stays nil until InitLog runs;
+// CheckMaliciousRepoBranch invokes log.Error on the invalid-input path and
+// nil-derefs without it. The existing Ginkgo suite calls InitLog inside an
+// It block, which is not guaranteed to run before these tests.
+func init() {
+	log.InitLog(true, "", "", "validation_test", "validation_test")
+}
+
+// Tier-3 input-validation safety net. Pins the contract of the three malicious
+// input validators so SSRF/path-traversal hardening (gap #10) can land safely.
+// Table rows that test desired-but-not-yet-implemented blocks are nested under
+// t.Skip subtests so the parent test stays green on current code.
+
+// TestCheckMaliciousRepoURL asserts the URL validator's contract for both
+// (a) inputs that must remain accepted regardless of future hardening, and
+// (b) SSRF/credential-leak vectors that are NOT yet blocked (gap #10).
+func TestCheckMaliciousRepoURL(t *testing.T) {
+	t.Parallel()
+
+	validCases := []struct {
+		name        string
+		input       string
+		wantBlocked bool
+		reason      string
+	}{
+		{"https_github", "https://github.com/org/repo.git", false, "normal HTTPS clone URL"},
+		{"ssh_github", "git@github.com:org/repo.git", false, "normal SSH clone URL"},
+		{"https_gitlab", "https://gitlab.com/org/repo.git", false, "normal HTTPS GitLab URL"},
+		{"https_bitbucket", "https://bitbucket.org/org/repo.git", false, "normal HTTPS Bitbucket URL"},
+	}
+	for _, tc := range validCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := util.CheckMaliciousRepoURL(tc.input)
+			gotBlocked := err != nil
+			if gotBlocked != tc.wantBlocked {
+				t.Errorf("CheckMaliciousRepoURL(%q): wantBlocked=%v gotBlocked=%v err=%v (%s)",
+					tc.input, tc.wantBlocked, gotBlocked, err, tc.reason)
+			}
+		})
+	}
+
+	t.Run("gap_10_ssrf_targets_not_yet_blocked", func(t *testing.T) {
+		t.Skip("Gap #10 — remove this Skip after CheckMaliciousRepoURL blocks RFC1918, link-local, loopback, file://, and credentials-in-URL")
+
+		ssrfCases := []struct {
+			name        string
+			input       string
+			wantBlocked bool
+			reason      string
+		}{
+			{"rfc1918_10x", "http://10.0.0.1/repo.git", true, "RFC1918 — SSRF"},
+			{"rfc1918_192", "http://192.168.1.1/repo.git", true, "RFC1918 — SSRF"},
+			{"rfc1918_172", "http://172.16.0.1/repo.git", true, "RFC1918 — SSRF"},
+			{"link_local", "http://169.254.169.254/repo.git", true, "link-local — cloud metadata endpoint"},
+			{"loopback_name", "http://localhost/repo.git", true, "loopback — SSRF"},
+			{"loopback_ip", "http://127.0.0.1/repo.git", true, "loopback — SSRF"},
+			{"file_scheme", "file:///etc/passwd", true, "file:// scheme — local file read"},
+			{"creds_in_url", "https://user:ghp_abc@github.com/org/repo.git", true, "credentials in URL — PAT leakage to logs"},
+		}
+		for _, tc := range ssrfCases {
+			t.Run(tc.name, func(t *testing.T) {
+				_, err := util.CheckMaliciousRepoURL(tc.input)
+				gotBlocked := err != nil
+				if gotBlocked != tc.wantBlocked {
+					t.Errorf("CheckMaliciousRepoURL(%q): wantBlocked=%v gotBlocked=%v err=%v (%s)",
+						tc.input, tc.wantBlocked, gotBlocked, err, tc.reason)
+				}
+			})
+		}
+	})
+}
+
+// branchValidatorVerdict runs CheckMaliciousRepoBranch with a fresh
+// echo.Context so the recorder's status code can act as the "blocked" signal.
+// Returns true if the validator wrote a 4xx/5xx response (i.e. blocked).
+func branchValidatorVerdict(t *testing.T, branch string) bool {
+	t.Helper()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	_ = util.CheckMaliciousRepoBranch(branch, c)
+	return rec.Code >= 400
+}
+
+// TestCheckMaliciousBranch asserts the branch validator blocks shell
+// metacharacters and null bytes today; the path-traversal cases ride a
+// skipped subtest because the regex currently allows "." and "/".
+func TestCheckMaliciousBranch(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		input       string
+		wantBlocked bool
+		reason      string
+	}{
+		{"shell_semicolon", "main; rm -rf /", true, "shell injection via semicolon"},
+		{"cmd_substitution", "$(whoami)", true, "command substitution $()"},
+		{"backtick_sub", "`id`", true, "backtick command substitution"},
+		{"null_byte", "main\x00suffix", true, "null byte injection"},
+		{"simple", "main", false, "standard branch name"},
+		{"slash", "feature/my-branch", false, "branch with single slash"},
+		{"release", "release-1.0.0", false, "semver-style release branch"},
+		{"numbers", "sprint-42", false, "branch with numbers"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := branchValidatorVerdict(t, tc.input)
+			if got != tc.wantBlocked {
+				t.Errorf("CheckMaliciousRepoBranch(%q): wantBlocked=%v got=%v (%s)",
+					tc.input, tc.wantBlocked, got, tc.reason)
+			}
+		})
+	}
+
+	t.Run("gap_path_traversal_not_yet_blocked", func(t *testing.T) {
+		t.Skip("Branch path-traversal gap — remove this Skip after CheckMaliciousRepoBranch (util.go:184) rejects '..' segments")
+
+		traversal := []struct {
+			name        string
+			input       string
+			wantBlocked bool
+			reason      string
+		}{
+			{"path_traversal", "../../../etc/passwd", true, "path traversal"},
+			{"double_dot", "branch/../../../secret", true, "path traversal via .."},
+		}
+		for _, tc := range traversal {
+			t.Run(tc.name, func(t *testing.T) {
+				got := branchValidatorVerdict(t, tc.input)
+				if got != tc.wantBlocked {
+					t.Errorf("CheckMaliciousRepoBranch(%q): wantBlocked=%v got=%v (%s)",
+						tc.input, tc.wantBlocked, got, tc.reason)
+				}
+			})
+		}
+	})
+}
+
+// TestCheckMaliciousChangedFiles asserts the changed-files validator blocks
+// shell metacharacters and null bytes today; path-traversal and absolute
+// paths ride a skipped subtest because the current regex permits "." and "/".
+func TestCheckMaliciousChangedFiles(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		input       string
+		wantBlocked bool
+		reason      string
+	}{
+		{"null_byte", "main.go\x00evil", true, "null byte in filename"},
+		{"semicolon", "file.go; rm -rf /", true, "shell injection"},
+		{"go_file", "main.go", false, "normal Go source file"},
+		{"nested_go", "pkg/util/util.go", false, "nested Go source file"},
+		{"python_file", "src/app.py", false, "normal Python file"},
+		{"multiple_dots", "my.config.yaml", false, "filename with multiple dots"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := util.CheckMaliciousChangedFiles(tc.input)
+			gotBlocked := err != nil
+			if gotBlocked != tc.wantBlocked {
+				t.Errorf("CheckMaliciousChangedFiles(%q): wantBlocked=%v gotBlocked=%v err=%v (%s)",
+					tc.input, tc.wantBlocked, gotBlocked, err, tc.reason)
+			}
+		})
+	}
+
+	t.Run("gap_path_and_absolute_not_yet_blocked", func(t *testing.T) {
+		t.Skip("Changed-files path/absolute gap — remove this Skip after CheckMaliciousChangedFiles (util.go:204) rejects '..' and leading '/'")
+
+		extra := []struct {
+			name        string
+			input       string
+			wantBlocked bool
+			reason      string
+		}{
+			{"path_traversal", "../../../etc/passwd", true, "path traversal"},
+			{"absolute_path", "/etc/passwd", true, "absolute path"},
+		}
+		for _, tc := range extra {
+			t.Run(tc.name, func(t *testing.T) {
+				err := util.CheckMaliciousChangedFiles(tc.input)
+				gotBlocked := err != nil
+				if gotBlocked != tc.wantBlocked {
+					t.Errorf("CheckMaliciousChangedFiles(%q): wantBlocked=%v gotBlocked=%v err=%v (%s)",
+						tc.input, tc.wantBlocked, gotBlocked, err, tc.reason)
+				}
+			})
+		}
+	})
+}

--- a/client/analysis/exitcode_test.go
+++ b/client/analysis/exitcode_test.go
@@ -1,0 +1,127 @@
+// Copyright 2026 Globo.com authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package analysis
+
+import (
+	"testing"
+
+	"github.com/githubanotaai/huskyci-api/client/types"
+)
+
+// Tier-2 client contract. Protects the exit-code 190 signal that GitHub Actions
+// pipelines consume to distinguish "scan ran and found blockers" from "scan
+// infrastructure failed".
+//
+// TESTABILITY GAP: the actual os.Exit calls live inline in client/cmd/main.go
+// (lines 32, 44, 55, 82, 98 for os.Exit(1); line 112/125 for os.Exit(0); line
+// 145 for os.Exit(190)). They can't be unit-tested without subprocess tricks.
+// However, the decision driving them is purely a function of the package-level
+// booleans types.FoundVuln and types.FoundInfo, which prepareAllSummary sets
+// from the API response. Testing that function pins the exact same decision
+// surface the main() switch reads.
+//
+// These tests cannot run in parallel — types.FoundVuln, types.FoundInfo, and
+// the package-level outputJSON are shared mutable state.
+
+// resetSummaryState clears all globals that prepareAllSummary mutates so each
+// test starts from a clean slate.
+func resetSummaryState() {
+	outputJSON = types.JSONOutput{}
+	types.FoundVuln = false
+	types.FoundInfo = false
+}
+
+// TestExitDecision_190WhenBlockingVulnerabilitiesFound:
+// CONTRACT: the client exits 190 when blocking (HIGH or MEDIUM) vulnerabilities
+// are present. This is an intentional, load-bearing CI/CD signal — pipelines
+// rely on the distinction between "scan failed" (exit 1) and "scan found bugs"
+// (exit 190). Do not change this value.
+func TestExitDecision_190WhenBlockingVulnerabilitiesFound(t *testing.T) {
+	resetSummaryState()
+
+	analysis := types.Analysis{
+		HuskyCIResults: types.HuskyCIResults{
+			GoResults: types.GoResults{
+				HuskyCIGosecOutput: types.HuskyCISecurityTestOutput{
+					HighVulns: []types.HuskyCIVulnerability{
+						{
+							Language:     "Go",
+							SecurityTool: "GoSec",
+							Severity:     "HIGH",
+							Title:        "Use of weak cryptographic primitive",
+							File:         "main.go",
+							Line:         "12",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	prepareAllSummary(analysis)
+
+	if !types.FoundVuln {
+		t.Fatal("expected types.FoundVuln=true with a HIGH vuln present (would cause main() to os.Exit(190))")
+	}
+	// Sanity check on the summary the main() switch also reads.
+	if !outputJSON.Summary.GosecSummary.FoundVuln {
+		t.Error("expected GosecSummary.FoundVuln=true")
+	}
+	if outputJSON.Summary.TotalSummary.HighVuln != 1 {
+		t.Errorf("expected TotalSummary.HighVuln=1, got %d", outputJSON.Summary.TotalSummary.HighVuln)
+	}
+}
+
+// TestExitDecision_0WhenNoVulnerabilitiesFound asserts the clean-scan path:
+// no findings of any severity → FoundVuln and FoundInfo both false →
+// main() takes the os.Exit(0) branch at client/cmd/main.go:112.
+func TestExitDecision_0WhenNoVulnerabilitiesFound(t *testing.T) {
+	resetSummaryState()
+
+	analysis := types.Analysis{
+		Result:         "passed",
+		HuskyCIResults: types.HuskyCIResults{},
+	}
+
+	prepareAllSummary(analysis)
+
+	if types.FoundVuln {
+		t.Error("expected types.FoundVuln=false on empty results")
+	}
+	if types.FoundInfo {
+		t.Error("expected types.FoundInfo=false on empty results")
+	}
+}
+
+// TestExitDecision_NonZeroNotOneNinetyWhenAPIUnreachable documents the
+// invariant: the API-error exit code MUST differ from the vulnerability-
+// found exit code so CI pipelines can distinguish the two situations.
+//
+// TESTABILITY GAP: API-error exits live inline as os.Exit(1) at main.go:32,
+// 44, 55, 82, 98 — none are extracted into a callable function. The test
+// pins the literal-vs-literal invariant instead of executing main().
+//
+// PROBABLE GAP: a future refactor should hoist these into named constants
+// (e.g. ExitOK=0, ExitAPIError=1, ExitVulnFound=190) and a thin
+// decideExitCode(types.Analysis, error) int helper so the exact decision
+// can be exercised here without subprocess plumbing.
+func TestExitDecision_NonZeroNotOneNinetyWhenAPIUnreachable(t *testing.T) {
+	const (
+		apiErrorExit  = 1   // client/cmd/main.go:32, 44, 55, 82, 98
+		vulnFoundExit = 190 // client/cmd/main.go:145
+		cleanScanExit = 0   // client/cmd/main.go:112, 125
+	)
+
+	if apiErrorExit == vulnFoundExit {
+		t.Fatalf("apiErrorExit (%d) must not equal vulnFoundExit (%d) — CI consumers rely on the distinction",
+			apiErrorExit, vulnFoundExit)
+	}
+	if apiErrorExit == cleanScanExit {
+		t.Fatalf("apiErrorExit (%d) must not equal cleanScanExit (%d)", apiErrorExit, cleanScanExit)
+	}
+	if apiErrorExit == 0 {
+		t.Fatalf("apiErrorExit must be non-zero, got %d", apiErrorExit)
+	}
+}

--- a/docs/assessments/general-gap-assessment-01.md
+++ b/docs/assessments/general-gap-assessment-01.md
@@ -1,0 +1,286 @@
+# HuskyCI Platform — Comprehensive Gap Assessment
+
+> **Note on deliverable shape.** The `/plan` slash command requested an implementation plan, but the `/plan` user prompt requested a research report. Treating this file as the requested research report. No code changes proposed.
+
+---
+
+## Executive Summary
+
+**Repository purpose & architecture.** HuskyCI is a CI/CD-orchestrated security-scan platform composed of three independent Go modules (`api/`, `client/`, `cli/`). The client posts a scan request to the API (`POST /analysis`); the API fans out per-scanner workloads as Docker containers or Kubernetes pods, parses each tool's JSON stdout, and persists results to MongoDB. Scanner containers (enry, gitleaks, gosec, bandit, npm/yarn/pnpm audit, wizcli variants, etc.) clone the repo themselves — the API never fetches code. The client polls results and exits `190` when blocking vulnerabilities are present (an intentional, load-bearing signal to GitHub Actions). Scanner registration is data-driven (`api/config.yaml` + a `securityTest` MongoDB collection) but every new scanner still requires seven coordinated source edits with no compile-time enforcement.
+
+**Top 10 gaps (severity × likelihood).**
+
+| # | Gap | Severity |
+|---|---|---|
+| 1 | Non-constant-time comparison for basic-auth password hash and token random data → timing side channel | **High** |
+| 2 | `Docker.WaitContainer(timeOutInSeconds)` parameter is dead — uses `context.Background()`; per-scanner timeouts are not enforced in Docker mode | **High** |
+| 3 | Unbounded goroutine fan-out across concurrent scans (no `errgroup.SetLimit`, no semaphore, no queue) — N scans × M scanners → N·M concurrent container starts | **High** |
+| 4 | No graceful shutdown / no orphaned-container reaper → API restart leaves analyses stuck in `"running"` indefinitely and Docker/K8s resources behind | **High** |
+| 5 | Kubernetes pod spec has no `securityContext` (no `runAsNonRoot`, no `readOnlyRootFilesystem`, no dropped capabilities, no seccompProfile) | **High** |
+| 6 | Scanner images pinned by mutable tags (some `latest`); no digest pinning → silent supply-chain drift | **High** |
+| 7 | No panic-recovery in scanner `analyze*` functions — a malformed tool output panics the goroutine; errgroup converts the panic into a re-raise that can crash the API process | **High** |
+| 8 | `setFinalResult` (run.go:81) runs **before** `defer setToAnalysis()` (run.go:65) — `setToAnalysis` unconditionally resets `FinalResult = "passed"` on success path, masking the per-container computation | **High** |
+| 9 | No tests for the core orchestration path (`api/analysis/StartAnalysis`) and no parser tests for 7 of ~12 scanners (gosec, bandit, npmaudit, yarnaudit, brakeman, spotbugs, tfsec, safety) | **Medium** |
+| 10 | No structured logging, no metrics endpoint, no readiness probe, no operator-facing audit trail → incident-response blind spots for OOM/crash/orphan analyses | **Medium** |
+
+**Maturity assessment.** The platform is **functionally complete and operationally fragile**. Scanner orchestration, MongoDB persistence, basic auth, per-repo token binding, delta scanning, and CI scan-contracts (gitleaks v8 fixture, deployment shell `bash -n`) are all implemented with reasonable care. But several load-bearing primitives are either missing (concurrency limits, request-correlated logging, container resource limits, K8s security context) or quietly broken (Docker timeout, finalization-order bug). Security posture is good at the perimeter (input regex, sandboxed `git clone`, per-repo token scoping, PBKDF2 password hashing) and weak at the depth (timing comparisons, secret-in-URL logging, scanner config trustfully loaded from a writable MongoDB collection). Production readiness for high scan volume or multi-tenant trust requires the High-severity items in the roadmap.
+
+---
+
+## Confirmed Gaps
+
+### Non-constant-time comparison in basic auth and token validation
+**Severity:** High
+**Evidence:** `api/auth/auth.go:35` — `if passDB != hashedPass { return false, nil }`; `api/token/token.go:92` — `if hashval != hashdata { return errors.New("Hash value from random data is different") }`. Neither uses `crypto/subtle.ConstantTimeCompare`. PBKDF2 (`api/auth/pbkdf2caller.go`) raises offline brute-force cost but does nothing for an online timing oracle.
+**Risk:** Network timing analysis can leak the hashed password / hashed random data byte-by-byte. With a few thousand requests an attacker can recover the comparison target without knowing PBKDF2 parameters. Combined with **#3** (no rate limiting) the oracle is unbounded.
+**Recommendation:** Replace both string-inequality checks with `subtle.ConstantTimeCompare([]byte(a), []byte(b)) != 1`. Add per-IP and per-token rate limiting (Echo middleware or in front-proxy).
+
+---
+
+### Docker scanner timeout is a no-op
+**Severity:** High
+**Evidence:** `api/dockers/api.go:99-116` — `WaitContainer(timeOutInSeconds int)` declares the parameter but builds `ctx := goContext.Background()` and never references `timeOutInSeconds`. Compare with K8s mode (`api/kubernetes/api.go::WaitPod`) which does honour `TimeoutSeconds` via `ListOptions`. Per-scanner timeouts declared in `api/config.yaml` (e.g. gosec `timeOutInSeconds: 360`, spotbugs `3600`) are read, threaded through `SecTestScanInfo.Start()`, and dropped on the floor in Docker mode.
+**Risk:** A hung scanner (network stuck on `git clone`, runaway analyzer) blocks its goroutine forever in Docker mode. The parent analysis never completes; `errgroup.Wait` never returns; the goroutine is non-cancellable. Combined with **#3** this is a denial-of-service primitive.
+**Recommendation:** `ctx, cancel := goContext.WithTimeout(goContext.Background(), time.Duration(timeOutInSeconds)*time.Second); defer cancel()`. On timeout, also call `ContainerStop` and `ContainerRemove` to free resources.
+
+---
+
+### Unbounded goroutine fan-out for concurrent scans
+**Severity:** High
+**Evidence:** `api/securitytest/run.go:67-83`, `86-128`, `131-185` — each call to `Start()` opens two `errgroup.WithContext(context.Background())` and within each, every `genericTests[i]` and every `languageTests[i]` is dispatched with bare `g.Go(...)`. No `errgroup.Group.SetLimit`, no buffered semaphore, no work queue. Routes (`api/routes/analysis.go::ReceiveRequest`) accept the request and spawn `StartAnalysis` without a rate limit.
+**Risk:** A burst of K concurrent scan requests, each spawning ~12 scanners, attempts K·12 simultaneous container starts. Docker daemon / K8s API will eventually reject, but goroutines pile up first; memory grows linearly; failure mode under load is "everything stuck" rather than "graceful 503". Tests must hit shared Docker socket → noisy-neighbour saturation across tenants.
+**Recommendation:** (a) Apply `errgroup.Group.SetLimit(N)` per analysis to cap intra-analysis concurrency. (b) Introduce a global semaphore (or token-bucket middleware) bounding system-wide concurrent scans; reject overflow with 429.
+
+---
+
+### No graceful shutdown; orphaned containers and stuck analyses on restart
+**Severity:** High
+**Evidence:** `api/server.go` registers `middleware.Recover()` but does not register `signal.Notify`/`server.Shutdown`. `api/analysis/analysis.go::StartAnalysis` writes `status:"running"` to MongoDB then returns to caller while goroutines continue. If the process is killed (deploy, OOM, panic), the only place those goroutines could clean up is the deferred `registerFinishedAnalysis` — which never fires for a `SIGKILL`. No background reaper scans Mongo for stale `"running"` analyses.
+**Risk:** Every API restart leaks one Docker container or K8s pod per in-flight scanner and one stuck Mongo row per in-flight analysis. The client polls `GET /analysis/:id` forever (or until the client times out — which the repo does not document a value for).
+**Recommendation:** Add a top-level signal handler that calls `server.Shutdown(ctx)` and a deadlined `WaitGroup` over in-flight analyses. Add a sweeper goroutine: every N minutes, find analyses with `status=running, startedAt < now - max(timeOutInSeconds)`; mark `status="error running", finalResult="error", error="reaped after restart"`.
+
+---
+
+### Kubernetes pod spec has no securityContext
+**Severity:** High
+**Evidence:** `api/kubernetes/api.go::CreatePod` (per Phase-3 agent, lines 104-141) builds the pod spec without a `SecurityContext` at pod or container level. No `runAsNonRoot`, no `readOnlyRootFilesystem`, no `allowPrivilegeEscalation: false`, no `capabilities.drop: [ALL]`, no seccomp profile.
+**Risk:** A malicious or compromised scanner image (or a CVE in a trusted scanner image — wizcli, gitleaks, etc. evolve weekly) runs as root with a writable rootfs and the default Linux capability set. Combined with **#6** (mutable tags), supply-chain compromise of one scanner image gives root in the scanner pod, which depending on the cluster's PodSecurityStandard may pivot to node compromise.
+**Recommendation:** Add `SecurityContext: { RunAsNonRoot: ptr.To(true), RunAsUser: ptr.To(int64(1000)), AllowPrivilegeEscalation: ptr.To(false), ReadOnlyRootFilesystem: ptr.To(true), Capabilities: { Drop: ["ALL"] }, SeccompProfile: { Type: "RuntimeDefault" } }`. Verify each scanner image still functions; any that need `/tmp` write get an `emptyDir` volume.
+
+---
+
+### Scanner images pinned by mutable tags
+**Severity:** High
+**Evidence:** `api/config.yaml` uses `imageTag:` fields with values like `1dd950e-amd64`, `v2.3.0`, and (per Phase-3 agent) at least one `latest`. Gitleaks image/tag is overridable via env (`api/context/context.go:444-450`) but no per-scanner digest pin. The CI `gitleaks-contract` job asserts the *built* image produces the expected behaviour, but the *runtime* pull resolves the tag at scan time — drift between CI's build and production's pull is invisible.
+**Risk:** Image registry compromise, tag re-push, or accidental scanner upgrade silently changes scan behaviour for every customer in flight. False-negative regressions in security tools are particularly insidious — they look like "good news".
+**Recommendation:** Pin every scanner image by `@sha256:` digest in `config.yaml`. Add a CI job that resolves each tag to a digest weekly and opens a PR if drift is detected (Renovate or a simple `crane digest` script).
+
+---
+
+### No panic recovery in scanner analyze* functions
+**Severity:** High
+**Evidence:** `api/securitytest/run.go:100-124` and `149-181` — `g.Go(func() error { ... runner.startScan(scan) ... })` with no `defer func() { recover() }`. `securitytest.go` dispatches to `securityTestAnalyze[name](scanInfo)` which calls per-tool unmarshalling logic. The middleware-level `middleware.Recover()` only catches panics in the HTTP request goroutine, not in detached analysis goroutines spawned later.
+**Risk:** Any per-tool parser (`api/securitytest/gosec.go`, `bandit.go`, `wizcli.go`, etc.) that hits a nil-deref on malformed JSON brings down the API process. Scanner output is parsed-but-not-trusted — a compromised scanner image or a tool that ships malformed JSON on the next release is a remote crash primitive.
+**Recommendation:** Wrap each `g.Go` body with `defer func(){ if r := recover(); r != nil { err = fmt.Errorf("scan panic: %v", r) } }()` and return the error normally. Add a panic counter metric.
+
+---
+
+### Finalization-order bug: setFinalResult is clobbered by deferred setToAnalysis
+**Severity:** High
+**Evidence:** `api/securitytest/run.go:63-83`:
+```go
+func (results *RunAllInfo) Start(enryScan SecTestScanInfo) error {
+    results.Codes = enryScan.Codes
+    defer results.setToAnalysis()           // line 65 — runs LAST
+    ...
+    if err := g.Wait(); err != nil { ... }
+    results.setFinalResult()                 // line 81 — runs BEFORE the defer
+    return nil
+}
+```
+Then `setToAnalysis` (run.go:243-277) unconditionally sets `results.FinalResult = "passed"` on entry (line 246) before recomputing from `container.CResult` values, while `setFinalResult` (run.go:324-340) computes `FinalResult` from a *different* signal (also `container.CResult == "failed"`, but ignoring `"warning"` and the JS-warning special case).
+**Risk:** `setFinalResult`'s value is always thrown away. Either the function is dead code (then delete it) or the intended semantics are silently wrong (then the bug is observable in customer-facing scan results). Possibly explains why `setFinalResult` exists alongside `setToAnalysis` with overlapping logic — appears to be a half-finished refactor.
+**Recommendation:** Read the git history to determine which is the intended finalizer, delete the other, and add a test that exercises a mixed-result analysis (one `failed`, one `warning`, one `passed`) and asserts the final value.
+
+---
+
+### Scanner config is trust-loaded from a writable MongoDB collection
+**Severity:** High
+**Evidence:** `api/securitytest/run.go:279-293` — `getAllDefaultSecurityTests` runs `FindAllDBSecurityTest` and returns whatever `cmd` strings are stored. `cmd` strings are then expanded by `HandleCmd` and executed in the scanner container by `/bin/sh -c`. There is no signature, no integrity check, no allowlist of `cmd` templates. The `securityTest` collection has no API-level writer, but any process with MongoDB credentials can rewrite a scanner's `cmd` to arbitrary shell.
+**Risk:** A MongoDB compromise (credentials in `.env`, network exposure, replica reachable from compromised pod) escalates directly to RCE in every scanner container on the next scan. The blast radius is "every customer". Combined with **#5** (no securityContext), that's root in the cluster.
+**Recommendation:** Treat scanner `cmd` templates as code, not data: ship them in `config.yaml` only, read them from disk, and use the MongoDB row solely for the enable/disable flag and language metadata. Or sign the `cmd` field with a deploy-time key and verify on load.
+
+---
+
+### Repository URL regex allows internal targets (limited SSRF)
+**Severity:** Medium
+**Evidence:** `api/util/util.go:169-181` — `CheckMaliciousRepoURL` regex `((git|ssh|http(s)?)|((git@|gitlab@)[\w\.]+))(:(//)?)([\w\.@\:/\-~]+)(\.git)(/?)`. Allows `http://10.0.0.1/repo.git`, `http://169.254.169.254/repo.git`, `git://localhost/repo.git`, etc.
+**Risk:** The URL is only ever consumed by `git clone` inside the scanner container, so the SSRF reach is bounded by the scanner pod's network policy. In a cluster without `NetworkPolicy` restricting egress, the scanner can hit cloud metadata services and exfiltrate IAM credentials. The risk is **conditional on missing K8s network policy** (which the repo does not ship).
+**Recommendation:** Block RFC1918, link-local (`169.254/16`), loopback, and `file://` in the validator. Ship an egress `NetworkPolicy` example alongside the scanner pod creation code.
+
+---
+
+### MongoDB: no indexes declared, no TTL, no query limits
+**Severity:** Medium
+**Evidence:** `api/db/mongo/mongo.go` — no `CreateIndex` calls. `api/db/huskydb.go` — `Find*` operations construct `bson.M` filters without `.SetLimit()`. `Analysis` documents embed `Containers []Container`, `Codes []Code`, and the nested `HuskyCIResults` with per-language vulnerability arrays — single-document size grows unbounded with scan output. No TTL index on the `analysis` collection.
+**Risk:** (a) Query performance degrades as collection grows (full-collection scans for `find({URL: ..., status: "running"})` style lookups). (b) Storage cost grows unboundedly; no retention policy. (c) Privacy/compliance exposure — repo URLs, commit author emails (`CommitAuthors []string`) and scan results persist forever.
+**Recommendation:** Declare indexes at startup (`URL+status`, `RID`, `createdAt`). Add a TTL index on `analysis.createdAt` (e.g. 90 days, configurable). Add `.SetLimit()` to any `Find*` whose result feeds a UI or aggregate. Document the retention SLA.
+
+---
+
+### Unused PostgreSQL backend is dead code
+**Severity:** Low (maintenance debt)
+**Evidence:** `api/db/postgres/` implements the same `Requests` interface as MongoDB but is never instantiated. `deployments/docker-compose.yml` has the Postgres service commented out. CLAUDE.md explicitly notes it's not wired up.
+**Risk:** Cognitive load (developers read it expecting it to matter), tests that don't run, dependency drift in `go.mod`. Lints / SCA scans waste effort on it.
+**Recommendation:** Delete `api/db/postgres/` and the commented compose service. If multi-backend support is a real future requirement, re-add when needed (the interface is preserved either way).
+
+---
+
+### Test coverage gaps in the core orchestration and per-tool parsers
+**Severity:** Medium
+**Evidence:** No test file for `api/analysis/analysis.go` (the orchestration entrypoint `StartAnalysis`). No `*_test.go` for 7 of the ~12 scanner parsers: `gosec.go`, `bandit.go`, `npmaudit.go`, `yarnaudit.go`, `brakeman.go`, `spotbugs.go`, `tfsec.go`, `safety.go`. No tests for `api/dockers/`, `api/db/mongo/`. The `scanRunner` mock interface (`runner.go`) exists — meaning the framework supports orchestration tests — but no test consumes it.
+**Risk:** A scanner-output schema change ships unnoticed until production. The finalization-order bug above (**#8**) would be caught instantly by an end-to-end test. Parser changes in `wizcli.go` (which *does* have tests) are well-protected; the others are not.
+**Recommendation:** Add one orchestration test using `mockRunner` that exercises a multi-scanner success path and one mixed-result path. For each of the 7 untested parsers, drop a 50-line sample of real tool output in `testdata/` and add an `assert HighVulns==N` test. Add a CI coverage floor (e.g. `-coverprofile` + `go tool cover` + threshold check) once the floor is established.
+
+---
+
+### CI lacks security and supply-chain scanning of the platform itself
+**Severity:** Medium
+**Evidence:** `.github/workflows/ci.yaml` runs `go vet`, `go build`, `go test -race`, `golangci-lint`, Docker build, the gitleaks fixture contract, and `bash -n` on deployment scripts. There is no gosec/govulncheck/nancy step, no `trivy`/`grype` image scan, no SBOM generation, no license check. The platform whose job is to scan customer code does not scan itself.
+**Risk:** Reputational and trust risk. Also material — `Makefile::check-sec` invokes gosec locally, so developers may assume CI does the same.
+**Recommendation:** Add `govulncheck ./...` per module (covers Go advisory DB), `gosec ./...` per module (already wired in Makefile, just move to CI), and `trivy image` against the API/client/scanner Dockerfiles.
+
+---
+
+### Observability: no structured logging, no metrics, no readiness probe
+**Severity:** Medium
+**Evidence:** `api/log/log.go` wraps `glbgelf` (Globo's GELF logger). Calls are positional (`SendLog(extra map, level, msgs)`); not key/value structured per modern observability conventions. No request-correlation ID propagated from `POST /analysis` through scanner goroutines (scan RID is logged but not threaded uniformly). No `/metrics` endpoint, no OpenTelemetry, no Prometheus exporter. `/healthcheck` exists but no `/readiness` (no DB-reachability gate); K8s would route traffic to a pod that can't talk to MongoDB.
+**Risk:** Incident response is slow. "Why are scans backing up?" requires log archaeology rather than a queue-depth metric. "Why is the deploy failing?" — no readiness probe to fail-fast.
+**Recommendation:** Switch to `zap`/`zerolog` with mandatory `scan_id`, `request_id`, `repo_url_hash` fields. Add `/metrics` (prom-client-go) with at minimum: in-flight scans, scan duration histogram (per scanner), scanner failure counter (per tool), auth failure counter. Add `/readiness` that pings MongoDB and the container runtime.
+
+---
+
+### Secrets in URLs may be logged
+**Severity:** Medium
+**Evidence:** `api/routes/analysis.go` (per Phase-3 agent, around line 159) logs `repository.URL` directly. A repository URL like `https://user:token@github.com/org/repo.git` is a valid input shape (and the most common shape for token-authenticated GitHub access). PBKDF2 / token storage is fine; the URL log is the leak.
+**Risk:** Centralized logs (GELF / Graylog / Datadog) end up holding plaintext PATs / SSH-cred-equivalents. Log-retention windows usually outlast credential rotation cadence.
+**Recommendation:** Add a `redactURL(u string) string` helper that strips `userinfo` before any log line. Audit all `log.*` call sites that take a URL.
+
+---
+
+### Container security: API mounts Docker socket (Docker mode)
+**Severity:** High *conditional* — confirm before committing
+**Evidence:** `deployments/docker-compose.yml` runs the API alongside a dockerd-in-docker service; the API authenticates via TLS certs (`api/dockers/api.go:53-64`). This is **safer** than mounting `/var/run/docker.sock` because the dockerd is in its own container. Need to verify the actual production deployment uses the same pattern (the K8s mode bypasses Docker entirely).
+**Risk:** If a production deployment mounts the host docker socket instead of using the TLS-isolated daemon, any scanner-image RCE = host root.
+**Recommendation:** Document the contract: "production deployment MUST run dockerd in a separate container with TLS, OR use K8s mode. Mounting /var/run/docker.sock is unsupported." Add a startup check that refuses to run if the docker host is `unix:///var/run/docker.sock`.
+
+---
+
+### No rate limiting on authenticated endpoints
+**Severity:** Medium
+**Evidence:** `api/server.go` does not register any rate-limit middleware. `/api/1.0` is basic-auth-only; `/analysis` is `Husky-Token`-only.
+**Risk:** Online brute force against either credential is unbounded (and amplified by **#1**'s timing oracle). Denial of service via scan-spam is unbounded (amplified by **#3**).
+**Recommendation:** Echo middleware `middleware.RateLimiter(middleware.NewRateLimiterMemoryStore(...))` per remote IP and per token. Tune to peak legitimate traffic + 2x.
+
+---
+
+## Probable Gaps
+
+### Container resource limits (CPU/memory) not visible on pod/container spec
+**Severity estimate:** Medium
+**Indicators:** Phase-2 agent saw no `core.ResourceRequirements` in `api/kubernetes/api.go::CreatePod` lines 104-141. Docker mode has no equivalent flag set in `CreateContainer` (`api/dockers/api.go:78-91`).
+**Investigation needed:** Read the full `CreatePod` body and check whether `Containers[0].Resources.Limits` is set. If absent, a malicious or pathological scan can OOM the node / saturate Docker host CPU.
+
+### Scanner stdout is read into memory before parsing
+**Severity estimate:** Medium
+**Indicators:** `api/dockers/api.go:188-203` `ReadOutput` uses `io.ReadAll` on container logs. No max-size bound. A scanner producing GB-scale output (verbose tool, infinite loop) would OOM the API.
+**Investigation needed:** Confirm there is no upstream container-log size cap in the Docker daemon config or K8s equivalent; if not, wrap with `io.LimitReader` at e.g. 100MB and treat overrun as a scan error.
+
+### Sparse-checkout shell logic is duplicated across all scanner cmd blocks
+**Severity estimate:** Low
+**Indicators:** CLAUDE.md explicitly warns "all scanner blocks (bandit, gosec, gitleaks, wizcli_*) follow the same pattern — keep them in sync." Manual synchronization across YAML blocks is a long-term drift hazard.
+**Investigation needed:** Read `config.yaml` and diff the sparse-checkout fragments — if there's any divergence today, the bug already exists. Possible mitigation: a shared shell function or a templated YAML include.
+
+### Analysis collection grows unbounded under repeated scans of the same repo
+**Severity estimate:** Medium
+**Indicators:** `api/routes/analysis.go::ReceiveRequest` (Phase-1 agent lines 84-214) checks DB for an in-flight scan on `(url, branch)` but does not de-duplicate completed scans. Each commit/PR push = new row indefinitely.
+**Investigation needed:** Read the de-dup logic and confirm; if confirmed, the TTL recommendation under "MongoDB" is the right mitigation.
+
+### No tests exercising MongoDB / Docker / K8s with real backends
+**Severity estimate:** Medium
+**Indicators:** Phase-6 agent found no integration test target in Makefile, no `docker-compose test` target, no `testcontainers` usage. All `db` and `kubernetes` tests appear to mock the interface.
+**Investigation needed:** Grep for `testcontainers`, `tcr`, or `compose up` in test files. If genuinely absent, an integration suite (using `testcontainers-go`) would protect the highest-leverage code path.
+
+---
+
+## Strengths
+
+Evidence-based. Do not omit when prioritizing — these are the load-bearing things to *not break*.
+
+- **Per-repository token scoping is enforced.** `api/token/token.go:120` `accessToken.URL != validURL` rejects cross-repo token use. Token A really cannot scan repo B.
+- **PBKDF2-SHA256 (100k iterations) password hashing.** `api/auth/pbkdf2caller.go:32-34, 54-63`. Salt is 64 bytes from `crypto/rand`. Iterations are configurable via env.
+- **Input validation is regex-allowlist, not denylist.** `api/util/util.go:184-198` (branch), `:204-219` (changed files), `:169-181` (repo URL — modulo the SSRF gap). All reject by default.
+- **Placeholders are quoted in scanner templates.** `api/config.yaml` wraps `%GIT_REPO%`, `%GIT_BRANCH%` in double quotes; combined with `strings.ReplaceAll` substitution (not `fmt.Sprintf`), shell injection is prevented even if the regex slipped.
+- **CI enforces two non-unit-test contracts.** `.github/workflows/ci.yaml:81-107` — gitleaks v8 + fixture finding shape; `:109-116` — `bash -n` on deployment scripts. These catch the failure modes that unit tests cannot.
+- **Race detector on every module.** CI runs `go test -race -count=1`. Unusual rigor for a Go service of this size.
+- **K8s `WaitPod` correctly enforces timeout via `ListOptions.TimeoutSeconds`.** `api/kubernetes/api.go::WaitPod`. Docker mode is the broken one (**#2**), not K8s.
+- **`mockRunner` exists for orchestration testing.** `api/securitytest/runner.go`. Framework supports the tests that should be written (**#9**).
+- **MongoDB connection has an auto-reconnect goroutine.** `api/db/mongo/mongo.go:77-94`. Survives transient DB blips.
+- **Three-module separation enforced in CI.** Each module's lint/build/test runs independently — a regression in `cli` cannot break `api`'s deploy.
+- **CLAUDE.md is comprehensive.** Three-tier architecture, scanner-addition checklist, delta-scan invariants, runtime kill-switches — all documented for the next contributor.
+- **Delta scanning has changedFiles validation.** `api/util/util.go::CheckMaliciousChangedFiles` + `routes/analysis.go:110` — recent addition (per CLAUDE.md), with a dedicated test file.
+
+---
+
+## Prioritized Roadmap
+
+### Immediate (0–30 days) — Critical/High items
+
+| Item | Effort | Impact | Dependencies |
+|---|---|---|---|
+| Fix Docker `WaitContainer` timeout (**#2**) | 1 day | Eliminates hang-forever scans | None |
+| Constant-time auth/token comparison + rate limiting (**#1**, **#17**) | 2 days | Closes timing oracle and brute-force vector | None |
+| Wrap each scanner `g.Go` with `defer recover()` (**#7**) | 1 day | API no longer crashes on malformed scanner output | None |
+| Diagnose & resolve `setFinalResult` / `setToAnalysis` order bug (**#8**) | 2 days incl. test | Restores correctness of scan finalization | Add the mixed-result test first to characterize current behaviour |
+| Add `errgroup.SetLimit` + global semaphore (**#3**) | 2 days | Bounds blast radius of scan bursts | None |
+| Pin scanner images by digest (**#6**) | 3 days | Closes silent supply-chain drift | Coordinate with scanner-image release cadence |
+| Strip credentials from logged repo URLs (**#16**) | half day | Stops PAT leakage to log aggregator | None |
+
+### Near-Term (30–90 days) — High/Medium and structural enablers
+
+| Item | Effort | Impact | Dependencies |
+|---|---|---|---|
+| Graceful shutdown + stale-analysis reaper (**#4**) | 1 week | Restart no longer leaks containers or stuck rows | None |
+| K8s `securityContext` hardening (**#5**) | 1 week incl. per-scanner verification | Closes scanner-image-RCE → root-in-pod escalation | Test each scanner under read-only rootfs |
+| Move scanner `cmd` templates out of MongoDB read-path (**#9**) | 1 week | Eliminates RCE-via-Mongo-compromise primitive | Coordinate with operators (deployment-time config) |
+| Govulncheck + gosec + trivy in CI (**#14**) | 3 days | Catches CVEs in the platform's own dependencies | None |
+| MongoDB indexes + TTL + query limits (**#11**) | 1 week | Bounds storage growth and query latency | Choose retention SLA with stakeholders |
+| Add orchestration test + parser tests for 7 missing scanners (**#13**) | 2 weeks | Catches the next finalization-order-style bug | Drop fixture JSON per scanner |
+| `/metrics` and `/readiness` endpoints (**#15**) | 1 week | Operators can see what's happening | None |
+| SSRF hardening on `CheckMaliciousRepoURL` (**#10**) | 2 days | Defense-in-depth even without NetworkPolicy | Coordinate with any existing internal-target test repos |
+
+### Long-Term (90+ days) — Medium/Low and architectural investments
+
+| Item | Effort | Impact | Dependencies |
+|---|---|---|---|
+| Structured logging migration (zap/zerolog with `scan_id`, `request_id`, `actor`) | 3 weeks | Materially better incident response | Coordinate with Graylog/SIEM pipeline |
+| OpenTelemetry tracing across API → scanner-pod boundary | 4 weeks | End-to-end latency visibility | Tracing backend (Jaeger/Tempo/honeycomb) |
+| Delete the unused Postgres backend (**#12**) | 1 day | Reduces cognitive load and lint surface | Confirm no dormant requirement |
+| Ship a Helm chart (or Kustomize base) for API deployment | 2 weeks | First-class K8s deployment story; today only docker-compose is documented | None |
+| Replace 11 MB `.gif` at repo root with externally-hosted asset | 1 day | Faster clones | Find a hosting location |
+| Multi-tenant authorization model (token → workspace → repo allowlist) | large; design first | Enables shared-infrastructure SaaS posture | Stakeholder requirements first |
+| Scanner-addition scaffolding (codegen for the 7 touchpoints) | 1 week | Reduces drift and onboarding friction (**Phase 8 finding**) | After **#9** completes — generator should write to the new template-on-disk pattern |
+
+---
+
+## Verification
+
+This is a research report, not an implementation. Validation steps:
+
+1. **Re-read each "Confirmed Gap"'s evidence line** — every claim cites file:line and can be opened directly.
+2. **Run the headline claims through git history.** `git blame api/auth/auth.go` line 35 should show the comparison has stood unchanged for years (i.e. it's a real gap, not a recent regression). Same for `api/dockers/api.go::WaitContainer`.
+3. **Reproduce the finalization-order bug (#8).** Add a unit test that calls `Start()` with a `mockRunner` returning two containers (`CResult="failed"`, `CResult="passed"`) and assert `results.FinalResult` — observe whether the deferred `setToAnalysis` overwrites the value set by `setFinalResult`.
+4. **Reproduce the Docker-timeout no-op (#2).** Stand up the docker-compose stack, inject a `cmd: "sleep 99999"` scanner in `config.yaml`, run a scan, observe `analysis.status` stays `running` past the configured `timeOutInSeconds`.
+5. **Confirm rate-limit absence (#17).** Hit `/api/1.0/analysis` 100x/sec from one IP. Expect 100% 200/401 (no 429). If 429 appears, the gap is wrong and remove from the report.
+
+If any verification disagrees with a finding, downgrade or remove that finding rather than keeping it on the strength of agent summary alone.

--- a/docs/assessments/performance-gap-assessment-01.md
+++ b/docs/assessments/performance-gap-assessment-01.md
@@ -1,0 +1,720 @@
+# HuskyCI API -- Performance Gap Assessment
+
+## Executive Summary
+
+Throughput posture: HuskyCI API accepts scans asynchronously, but it does not control the amount of work admitted after acceptance. `POST /analysis` returns quickly after validation and MongoDB preflight checks, then starts `analysis.StartAnalysis` in a detached goroutine (`api/routes/analysis.go:84-162`). Once accepted, each scan can fan out into one enry container plus generic and language scanner containers with no global semaphore, no queue, and no rejection policy. The real throughput ceiling is therefore not the HTTP server; it is the combined saturation point of Docker/Kubernetes, MongoDB collection scans, process memory, and Go scheduler overhead under unbounded goroutine growth.
+
+Latency posture: request acceptance latency is bounded by JSON binding, token validation, input regex checks, and unindexed MongoDB preflight reads. End-to-end scan completion latency is dominated by scanner container lifecycle and log/result processing. In Kubernetes mode, scheduling and scanner execution have explicit watch timeouts. In Docker mode, prior finding #2 means scanner execution has no effective deadline after container start; a stuck scanner can keep the analysis in `running` indefinitely. The largest configured scanner deadline is `spotbugs.timeOutInSeconds: 3600` in `api/config.yaml:397-451`, and in Docker mode even that upper bound is not enforced.
+
+Top 5 performance risks ranked by severity x likelihood:
+
+1. **Critical -- unbounded scan admission plus unbounded scanner fan-out:** `ReceiveRequest` spawns `StartAnalysis` with no queue (`api/routes/analysis.go:160`), and `RunAllInfo.Start` fans scanners out via unbounded errgroups (`api/securitytest/run.go:67-184`). Cross-reference: prior finding #3.
+2. **Critical -- unbounded scanner stdout/log buffering:** Docker and Kubernetes both read full scanner logs with `io.ReadAll` and no pre-read byte cap (`api/dockers/api.go:188-203`, `api/kubernetes/api.go:233-257`).
+3. **Critical -- Docker scanner timeout is ineffective:** Docker `WaitContainer` receives `timeOutInSeconds` but uses `context.Background()` and never applies the timeout (`api/dockers/api.go:99-116`). Cross-reference: prior finding #2.
+4. **High -- MongoDB hot-path queries are unindexed and grow linearly:** request dedupe, result polling, scanner metadata reads, and final analysis update all use query shapes with no declared indexes (`api/db/huskydb.go:37-72, 110-130, 249-279`; prior finding #11).
+5. **High -- no graceful shutdown or resource drain:** detached scans are not coordinated with process shutdown (`api/server.go:23-110`; prior finding #4), so restarts can leave containers/pods and `running` rows behind, increasing later scan and polling load.
+
+Observability readiness: performance cannot be measured today from the running service because there is no `/metrics`, no traces, no latency fields, no queue depth, and no propagated request/scan correlation beyond ad hoc RID logging.
+
+## Confirmed Performance Gaps
+
+### Accepted Scans Bypass Backpressure
+**Severity:** Critical
+**Phase:** 1, 2, 4
+**Evidence:** `api/routes/analysis.go:84-162`, specifically `go analysis.StartAnalysis(RID, repository)` at line 160.
+**Impact:** The HTTP handler returns `201 Created` after local validation and MongoDB preflight, before any scanner container is running. If scan requests arrive faster than Docker/Kubernetes can start containers, the API still accepts more work and accumulates detached goroutines. This is structural overload amplification: admission is O(requests), while work created is O(requests x scanners).
+**Cross-reference:** Prior finding #3.
+**Recommendation:** Replace direct goroutine spawn with a bounded work queue or global scan semaphore. Return `429 Too Many Requests` or `503 Service Unavailable` when the queue is full. Track queue depth and in-flight scans.
+**Benchmark needed:** `BenchmarkScanGoroutineFanout`.
+
+### Enry Is Synchronous Inside The Detached Scan Worker
+**Severity:** Medium
+**Phase:** 1
+**Evidence:** `api/analysis/analysis.go:20-95`; `enryScan.Start()` runs at lines 84-87 before `allScansResults.Start(enryScan)` at lines 90-93.
+**Impact:** Enry does not block the HTTP response, but it serializes the background critical path: no generic or language scanners start until enry finishes and language detection is parsed. Minimum scan completion latency is therefore at least the enry container lifecycle plus final Mongo update, even when every later scanner is instant.
+**Cross-reference:** New finding.
+**Recommendation:** Keep enry synchronous because later language scanner selection depends on it, but instrument `enry` separately and enforce the same timeout semantics in both Docker and Kubernetes modes.
+**Benchmark needed:** None -- statically verifiable.
+
+### Generic And Language Scanner Groups Run Concurrently, Not Sequentially
+**Severity:** Low
+**Phase:** 1
+**Evidence:** `api/securitytest/run.go:67-76` starts `runGenericScans` and `runLanguageScans` as two goroutines under one top-level errgroup. Nested waits occur inside `runGenericScans` (`api/securitytest/run.go:85-128`) and `runLanguageScans` (`api/securitytest/run.go:130-184`).
+**Impact:** Current source does not have two sequential top-level `Wait()` calls. A slow generic scanner does not prevent language scanners from starting after both wrapper goroutines are scheduled. The critical path is `enry duration + max(generic group duration, language group duration) + final Mongo update`, with runtime-container overhead and Mongo query latency inside each group.
+**Cross-reference:** New finding.
+**Recommendation:** Preserve concurrent group startup, but add `errgroup.SetLimit` or a weighted semaphore inside each group to cap scanner fan-out.
+**Benchmark needed:** `BenchmarkErrgroupFanout`.
+
+### Per-Scan Goroutine Fan-Out Has No Limit
+**Severity:** Critical
+**Phase:** 2
+**Evidence:** `api/securitytest/run.go:67-184`; each `g.Go` call is unconditional for enabled scanner tests, and no `SetLimit` or semaphore is used.
+**Impact:** Minimum spawned goroutines per accepted request is one detached `StartAnalysis` goroutine when enry fails before `RunAllInfo.Start`. If enry succeeds but no later tests exist, `RunAllInfo.Start` adds two wrapper goroutines. With all registered post-enry scanners active, current code can spawn `1 + 2 + 16 = 19` request-owned goroutines: one `StartAnalysis`, two group wrappers, six generic scanner goroutines, and ten language scanner goroutines including `spotbugs`. At N concurrent scans, this is:
+
+| Concurrent scans | Minimum, enry fails | Empty post-enry groups | All scanners active |
+|---:|---:|---:|---:|
+| 10 | 10 | 30 | 190 |
+| 100 | 100 | 300 | 1,900 |
+| 1,000 | 1,000 | 3,000 | 19,000 |
+
+Go goroutines are multiplexed over OS threads, so thousands of goroutines are expected to work structurally, but the point where scheduler overhead becomes measurable depends on blocking profile, stack growth, memory retention, and runnable goroutine count. Unable to verify from static analysis — requires benchmark: `BenchmarkScanGoroutineFanout` (specified in Phase 6).
+**Cross-reference:** Prior finding #3.
+**Recommendation:** Use a global semaphore for total active scanner containers and per-analysis limits for intra-analysis concurrency. Export `runtime.NumGoroutine` and scanner queue depth.
+**Benchmark needed:** `BenchmarkScanGoroutineFanout`, `BenchmarkErrgroupFanout`.
+
+### Docker Scanner Deadline Budget Is Not Enforced
+**Severity:** Critical
+**Phase:** 1, 4
+**Evidence:** `api/dockers/api.go:99-116`; `WaitContainer(timeOutInSeconds int)` ignores the argument and waits with `context.Background()`.
+**Impact:** In Docker mode, the configured scanner timeout is not a maximum latency bound. A hung container keeps its scanner goroutine, Docker resources, and parent analysis goroutine alive indefinitely. `spotbugs` is configured with `timeOutInSeconds: 3600` (`api/config.yaml:397-451`), but prior finding #2 means Docker mode can exceed that bound without returning.
+**Cross-reference:** Prior finding #2.
+**Recommendation:** Use `context.WithTimeout` in `WaitContainer`, stop/remove the container on timeout, and propagate timeout errors into `RunAllInfo.SetAnalysisError`.
+**Benchmark needed:** None -- statically verifiable.
+
+### Docker Image Pull Latency Is Outside Scanner Runtime Timeout
+**Severity:** High
+**Phase:** 1
+**Evidence:** `api/dockers/huskydocker.go:37-87`; image load/pull happens at lines 45-51 before `CreateContainer`, `StartContainer`, and `WaitContainer`. Pull retry timeout is independent: `time.After(15 * time.Minute)` at `api/dockers/huskydocker.go:89-109`.
+**Impact:** Docker image pull can add up to its own 15-minute budget before scanner execution begins. This budget is not the scanner's `timeOutInSeconds`, and in Docker mode scanner execution itself is unbounded because of prior finding #2. Image pull is cached at the daemon level via `ImageIsLoaded` (`api/dockers/api.go:232-246`), but cold hosts or tag drift can create a latency cliff per scanner image.
+**Cross-reference:** New finding.
+**Recommendation:** Pre-pull scanner images at startup or deployment, close/read image-pull streams correctly, expose image-pull latency metrics, and include image availability in readiness checks.
+**Benchmark needed:** None -- static control flow is verifiable; live pull latency requires deployment measurement.
+
+### Docker Client Is Created Per Scanner
+**Severity:** High
+**Phase:** 2
+**Evidence:** `api/dockers/huskydocker.go:37-43` calls `NewDocker` for every scanner; `api/dockers/api.go:39-75` creates a new Docker SDK client from environment variables.
+**Impact:** The API does not share a Docker client across concurrent scanners. Each scanner rebuilds client state and mutates process-wide Docker environment variables (`DOCKER_HOST`, `DOCKER_CERT_PATH`, `DOCKER_TLS_VERIFY`) at `api/dockers/api.go:46-66`. Whether HTTP connections pool across clients is not visible from this code, but this pattern prevents HuskyCI from imposing a central Docker request budget and increases pressure on the Docker daemon under scan bursts. Simultaneous `ContainerCreate` and `ContainerStart` calls eventually serialize or queue at the Docker daemon, but the API keeps producing goroutines first.
+**Cross-reference:** Prior finding #3.
+**Recommendation:** Build one Docker client per configured Docker host during startup, keep it immutable, and gate Docker operations through a per-host semaphore.
+**Benchmark needed:** `BenchmarkScanGoroutineFanout`.
+
+### Kubernetes Clientset Is Created Per Scanner With Default Client Rate Limits
+**Severity:** High
+**Phase:** 2
+**Evidence:** `api/kubernetes/huskykube.go:49-56` calls `NewKubernetes` per scanner; `api/kubernetes/api.go:36-65` builds a new config and `kube.NewForConfig(config)`. No custom `QPS` or `Burst` fields are set in the config.
+**Impact:** The client-go defaults are `DefaultQPS = 5.0` and `DefaultBurst = 10`, but this code creates a separate clientset per scanner rather than sharing one process-wide limiter. That can multiply API server pressure across concurrent scans while still leaving individual scanner goroutines waiting on client-side or API-server throttling. Pod scheduling latency is counted by `podSchedulingTimeoutInSeconds` until the pod reaches `Running`; scanner execution is then counted by `testTimeOutInSeconds` (`api/kubernetes/api.go:152-230`).
+**Cross-reference:** Prior finding #3.
+**Recommendation:** Build a shared Kubernetes clientset at startup, configure explicit `QPS`/`Burst` from environment, and add a global pod-create semaphore.
+**Benchmark needed:** `BenchmarkScanGoroutineFanout` for local fan-out; live API throttling requires cluster instrumentation.
+
+### Kubernetes WaitPod Has A Deadline Budget, But Log Collection Does Not
+**Severity:** High
+**Phase:** 1
+**Evidence:** `api/kubernetes/api.go:152-230` uses `metav1.ListOptions.TimeoutSeconds` for scheduling and running watches; `api/kubernetes/api.go:233-257` reads logs with `io.ReadAll`.
+**Impact:** Kubernetes mode bounds the wait for `Running` and terminal pod state, including image pull and scheduling while the pod is Pending. After the pod finishes, log retrieval remains unbounded by bytes read and can allocate until the API process runs out of memory.
+**Cross-reference:** New finding.
+**Recommendation:** Wrap pod log streams with `io.LimitReader`, emit output byte metrics, and fail scans that exceed a configured output limit.
+**Benchmark needed:** `BenchmarkReadOutputBuffering`.
+
+### Scanner Output Is Read Fully Into Memory Before Any Cap Applies
+**Severity:** Critical
+**Phase:** 1, 3
+**Evidence:** Docker `ReadOutput` uses `io.ReadAll(out)` and `string(body)` at `api/dockers/api.go:188-203`; Kubernetes does the same at `api/kubernetes/api.go:233-257`. The only output cap is post-read and post-parse: `cOutputMaxSize := 1000000` in `api/securitytest/securitytest.go:178-189`.
+**Impact:** There is no size bound on the log stream before allocation. `io.ReadAll` grows a byte slice for the full output, `string(body)` copies it, and most analyzers convert the string back to `[]byte` for JSON/XML parsing. A scanner that emits 100MB can transiently require multiple copies before the eventual stored `COutput` truncation. Spotbugs XML and dependency scanners can produce large outputs on large repositories.
+**Cross-reference:** New finding.
+**Recommendation:** Replace `io.ReadAll` with bounded reads (`io.LimitReader` or streaming decoder), return a typed "output too large" scan error when exceeded, and record the byte count before truncation.
+**Benchmark needed:** `BenchmarkReadOutputBuffering`.
+
+### Parse Error Path Can Retain Full Scanner Output In Error Strings
+**Severity:** High
+**Phase:** 3
+**Evidence:** `api/util/util.go:141-143` builds `fmt.Errorf("%s\nError from top: %v", containerOutput, otherErr)`. Parser call sites pass full `Container.COutput`, for example `api/securitytest/gosec.go:52-56`, `api/securitytest/bandit.go:39-41`, and `api/securitytest/spotbugs.go:110-115`.
+**Impact:** Even though `prepareContainerAfterScan` later truncates `Container.COutput`, parse failures can retain the complete raw output inside `scanInfo.ErrorFound`. `registerFinishedAnalysis` converts that error to a string for MongoDB at `api/analysis/analysis.go:116-135`, creating another large allocation and possibly a large `errorFound` field.
+**Cross-reference:** New finding.
+**Recommendation:** Change `HandleScanError` to include a bounded prefix/suffix and byte count, not the complete scanner output.
+**Benchmark needed:** `BenchmarkReadOutputBuffering`.
+
+### MongoDB Request-Acceptance Reads Are Unindexed
+**Severity:** High
+**Phase:** 2, 4
+**Evidence:** `ReceiveRequest` calls `FindOneDBRepository` with `{"repositoryURL": repository.URL}` (`api/routes/analysis.go:116-124`) and `FindOneDBAnalysis` with `{"repositoryURL": repository.URL, "repositoryBranch": repository.Branch}` (`api/routes/analysis.go:136-155`). Query builders are in `api/db/huskydb.go:37-72`. No indexes are declared in `api/db/mongo/mongo.go`.
+**Impact:** With prior finding #11, these preflight reads can become collection scans. MongoDB collection scans compare each document to the query predicate when no suitable index covers the query, so latency grows linearly with collection size. At 1k, 10k, and 100k documents, the expected growth function is O(N), not O(1); exact latency in milliseconds depends on data size, storage, cache state, and deployment. Unable to verify from static analysis — requires benchmark: `BenchmarkMongoAnalysisQueries` (specified in Phase 6).
+**Cross-reference:** Prior finding #11.
+**Recommendation:** Add indexes on `repository.repositoryURL`, `analysis.RID`, and compound `analysis.repositoryURL + analysis.repositoryBranch + analysis.status`. Query running analyses with `status:"running"` and use a deterministic sort or unique active-scan guard.
+**Benchmark needed:** `BenchmarkMongoAnalysisQueries`.
+
+### In-Flight Deduplication Is Not Effective Throttling
+**Severity:** High
+**Phase:** 2
+**Evidence:** Deduplication is a single `FindOneDBAnalysis` on URL and branch at `api/routes/analysis.go:136-155`; it only rejects if the returned document has `Status == "running"`.
+**Impact:** This is not a capacity control. It only targets duplicate URL+branch submissions and does not limit distinct repositories, distinct branches, or scanner fan-out. Because the query is not scoped to `status:"running"` and has no sort, completed analyses can interfere with the intended check, reducing any throttle effect under accumulated history.
+**Cross-reference:** Prior finding #11 for index absence; new performance consequence.
+**Recommendation:** Add a true global admission controller and replace dedupe with an indexed active-scan table or compound unique index for `(repositoryURL, repositoryBranch, status=running)`.
+**Benchmark needed:** `BenchmarkMongoAnalysisQueries`.
+
+### MongoDB Scanner Metadata Reads Multiply With Scanner Count
+**Severity:** Medium
+**Phase:** 2
+**Evidence:** `getAllDefaultSecurityTests` calls `FindAllDBSecurityTest` (`api/securitytest/run.go:279-293`). `runGenericScans` calls it once for `type:"Generic"` (`api/securitytest/run.go:85-92`); `runLanguageScans` calls it once per detected language (`api/securitytest/run.go:134-141`). Every scanner then calls `FindOneDBSecurityTest` in `SecTestScanInfo.New` (`api/securitytest/securitytest.go:69-91`).
+**Impact:** Even if the `securityTest` collection is small, scanner metadata reads are in the active scan hot path. At maximum scanner fan-out, the API repeats metadata lookups that could be immutable in memory. With prior finding #11, these are also unindexed collection scans if no default `_id` lookup is used.
+**Cross-reference:** Prior finding #11.
+**Recommendation:** Load scanner metadata into an immutable in-memory map at startup, refresh explicitly on admin changes, and remove per-scanner `FindOneDBSecurityTest` calls.
+**Benchmark needed:** `BenchmarkMongoAnalysisQueries`.
+
+### Final Analysis Update Can Hit MongoDB BSON Size Limit
+**Severity:** High
+**Phase:** 3
+**Evidence:** `registerFinishedAnalysis` writes `containers`, `huskyciresults`, `codes`, and `errorFound` into one analysis document (`api/analysis/analysis.go:116-135`). Types embed nested arrays in `api/types/types.go:32-160`.
+**Impact:** Analysis document growth is bounded only by MongoDB's 16 MiB BSON document limit, not by HuskyCI field-level limits. Large `Codes[]`, many `Containers[]`, and high vulnerability counts can make BSON encoding slow or fail the final update. The raw `io.ReadAll` output, parsed result structs, vulnerability arrays, and BSON encoding buffers can coexist briefly, creating double or triple allocation risk.
+**Cross-reference:** Prior finding #11.
+**Recommendation:** Store scanner outputs/findings in separate documents keyed by RID and scanner name, keep the analysis document as an indexable summary, and cap per-scan finding counts.
+**Benchmark needed:** `BenchmarkAnalysisBSONEncodingWorstCase`.
+
+### Polling Amplifies MongoDB Reads
+**Severity:** High
+**Phase:** 4
+**Evidence:** `GetAnalysis` queries by `RID` at `api/routes/analysis.go:44-80`; query builder is `FindOneDBAnalysis` at `api/db/huskydb.go:61-72`. No index on `RID` is declared in `api/db/mongo/mongo.go`.
+**Impact:** The client polling contract creates read load as:
+
+```text
+reads_per_second = concurrent_scans * (1 / poll_interval_seconds)
+```
+
+Polling becomes the dominant MongoDB read workload when `concurrent_scans / poll_interval_seconds` exceeds the active scan hot-path read rate. The exact crossing point cannot be derived statically because the repository does not enforce poll interval, scan duration distribution, or client retry limits. Because `RID` is not declared indexed, each poll can degrade from O(1) expected lookup to O(N) collection scan under prior finding #11.
+**Cross-reference:** Prior finding #11.
+**Recommendation:** Add a unique index on `analysis.RID`, enforce server-side polling rate limits, return `Retry-After`, and consider long polling or callback/webhook completion.
+**Benchmark needed:** `BenchmarkMongoAnalysisQueries`.
+
+### MongoDB Operations Use Contexts Without Deadlines
+**Severity:** Medium
+**Phase:** 4
+**Evidence:** MongoDB wrapper methods use `context.TODO()` for `InsertOne`, `UpdateOne`, `Find`, `FindOne`, `FindOneAndUpdate`, and cursor reads (`api/db/mongo/mongo.go:96-174`).
+**Impact:** Slow server selection, reconnect, collection scans, or network stalls are not bounded per operation in code. During reconnect, `autoReconnect` pings every second and calls `Disconnect`/`Connect` on the shared client (`api/db/mongo/mongo.go:76-94`). Whether in-flight queries queue, block, or fail depends on driver behavior and deployment state. Unable to verify from static analysis — requires benchmark: `BenchmarkMongoReconnectDuringScan` (specified in Phase 6).
+**Cross-reference:** Prior finding #11.
+**Recommendation:** Add per-operation contexts with deadlines and expose Mongo operation duration/error metrics.
+**Benchmark needed:** `BenchmarkMongoReconnectDuringScan`.
+
+### No Graceful Shutdown Drains In-Flight Work
+**Severity:** Critical
+**Phase:** 4
+**Evidence:** `api/server.go:23-110` starts Echo with `Start`/`StartTLS` and no signal handler, no `Shutdown`, and no in-flight analysis `WaitGroup`.
+**Impact:** On deploy/restart, detached analysis goroutines can terminate without finalizing Mongo rows or removing containers/pods. The next process starts with stale `running` rows, orphaned runtime resources, and clients polling old RIDs. Under repeated deploys or crashes, this increases background load and reduces available container capacity.
+**Cross-reference:** Prior finding #4.
+**Recommendation:** Add graceful shutdown with a bounded context, track active analyses, stop/remove active containers or pods, and run a stale-analysis reaper on startup.
+**Benchmark needed:** None -- statically verifiable; cleanup effectiveness needs integration testing.
+
+### CheckMaliciousRepoURL Recompiles Regex Per Request
+**Severity:** Low
+**Phase:** 6
+**Evidence:** `api/util/util.go:168-181` calls both `regexp.MustCompile(regexpGit)` and `regexp.MatchString(regexpGit, repositoryURL)` on every request.
+**Impact:** Regex compilation and duplicate matching add avoidable CPU allocation in the request-acceptance path. This is not the dominant cost compared with MongoDB and container runtime, but it is measurable under high rejected/accepted request rates.
+**Cross-reference:** New finding.
+**Recommendation:** Hoist the compiled regex to a package-level `var` and call `FindString`/`MatchString` once.
+**Benchmark needed:** `BenchmarkCheckMaliciousRepoURLConcurrent`.
+
+### Performance Instrumentation Is Absent
+**Severity:** High
+**Phase:** 5
+**Evidence:** No Prometheus/OpenTelemetry references in `api/go.mod:1-23`; only request ID middleware exists at `api/server.go:54-57`; logger wrapper accepts positional variadic messages with fixed `action` and `info` fields (`api/log/log.go:29-57`).
+**Impact:** The platform cannot answer core performance questions: request rate, scan concurrency, scanner duration, runtime saturation, output size, MongoDB latency, Docker/Kubernetes error rates, or goroutine count. Without those signals, tuning is guesswork and saturation is discovered after user-visible failures.
+**Cross-reference:** New finding.
+**Recommendation:** Add `github.com/prometheus/client_golang/prometheus` and `github.com/prometheus/client_golang/prometheus/promhttp`, expose `/metrics`, and instrument the exact locations listed in Phase 5 below.
+**Benchmark needed:** None for absence; metric usefulness validated operationally.
+
+## Probable Performance Gaps
+
+### Docker Daemon Serialization Under Container Bursts
+**Severity estimate:** High
+**Indicators:** Every scanner calls `ContainerCreate` (`api/dockers/api.go:77-91`) and `ContainerStart` (`api/dockers/api.go:93-97`) through per-scanner clients, with no HuskyCI-side semaphore.
+**Unable to verify because:** Docker daemon scheduling, image layer locks, HTTP connection behavior, and host capacity are external runtime properties.
+**Benchmark spec:**
+
+```text
+Benchmark name: BenchmarkDockerContainerStartBurst
+File: api/dockers/api_bench_test.go
+What it measures: ContainerCreate + ContainerStart latency under increasing parallel scanner starts.
+Setup: Local Docker daemon with scanner image pre-pulled and a no-op command image.
+Input range: Parallelism 1, 5, 10, 20, 50.
+Expected result: P95 start latency grows sublinearly until the configured daemon capacity.
+Regression threshold: Flag if P95 grows superlinearly or Docker errors appear before the intended global limit.
+Gap analysis reference: probable Docker runtime ceiling, prior finding #3.
+```
+
+### Kubernetes API Server Throttling Under Pod Bursts
+**Severity estimate:** High
+**Indicators:** `NewKubernetes` creates a clientset per scanner (`api/kubernetes/api.go:36-65`), and no explicit `QPS`/`Burst` is configured.
+**Unable to verify because:** API server throttling depends on cluster version, client config, admission controllers, and control-plane load.
+**Benchmark spec:**
+
+```text
+Benchmark name: BenchmarkKubernetesPodCreateBurst
+File: api/kubernetes/api_bench_test.go
+What it measures: Pod create + watch setup latency and client/server throttle errors under burst fan-out.
+Setup: Test namespace, shared no-op scanner image, cleanup hook for created pods.
+Input range: Parallel pod creates 1, 5, 10, 20, 50.
+Expected result: Latency and 429/throttle events stay within the configured client/server QPS budget.
+Regression threshold: Flag if pod creation P99 exceeds podSchedulingTimeout / 2 or any throttling appears below intended capacity.
+Gap analysis reference: probable Kubernetes runtime ceiling, prior finding #3.
+```
+
+### MongoDB Reconnect Effects On Active Scans
+**Severity estimate:** Medium
+**Indicators:** `autoReconnect` calls `Disconnect` and `Connect` on the shared client while all query methods use `context.TODO()` (`api/db/mongo/mongo.go:76-174`).
+**Unable to verify because:** In-flight behavior depends on MongoDB driver internals, server selection timeout, deployment topology, and timing of disconnect relative to operations.
+**Benchmark spec:**
+
+```text
+Benchmark name: BenchmarkMongoReconnectDuringScan
+File: api/db/mongo/mongo_bench_test.go
+What it measures: Query/update latency and error rate while the reconnect loop runs during active analysis operations.
+Setup: Test MongoDB instance, seeded analysis/securityTest collections, controlled network interruption or mock server.
+Input range: Concurrent scan DB operation counts 1, 10, 50 with reconnect intervals.
+Expected result: Operations either fail quickly with bounded errors or recover within configured deadlines.
+Regression threshold: Flag if any operation blocks beyond the configured DB timeout or goroutines leak.
+Gap analysis reference: probable reconnect latency gap, prior finding #11.
+```
+
+## Phase 1 -- Execution Path Latency Analysis
+
+### 1a. Request Acceptance Latency
+
+`ReceiveRequest` is asynchronous with respect to scan execution. The handler performs JSON binding, token authorization, input checks, repository lookup/insert, and active-analysis dedupe. It then starts `analysis.StartAnalysis` as a goroutine at `api/routes/analysis.go:160` and returns `201 Created` at `api/routes/analysis.go:161-162`.
+
+Minimum request acceptance latency is the local validation path plus MongoDB preflight calls. Maximum request acceptance latency is unbounded by code because MongoDB calls use `context.TODO()` in `api/db/mongo/mongo.go:96-174` and preflight queries have no indexes under prior finding #11. The HTTP client does not block for the full scan duration unless MongoDB preflight itself stalls.
+
+| Stage | Sync/async boundary | Minimum latency | Maximum latency in current code | Deadline budget consumed |
+|---|---|---|---|---|
+| `ReceiveRequest` validation and preflight | Synchronous before HTTP response | JSON bind + token auth + regex validation + Mongo preflight | Unbounded by code because Mongo operations have no per-call context deadline | MongoDB preflight dominates if collections grow |
+| `StartAnalysis` registration and enry | Asynchronous after line 160 | Insert running analysis + instant enry container/log parse | Docker mode unbounded if enry hangs; Kubernetes bounded by scheduling timeout + enry timeout + log read | Enry is mandatory and serial before other scanners |
+| Generic/language scanner fan-out | Asynchronous background errgroup | Instant scanner metadata reads + instant containers + instant parse | Docker mode unbounded per scanner; Kubernetes bounded by per-pod waits plus unbounded log byte reads | Slowest scanner group dominates |
+| Finalization | Background defer in `StartAnalysis` | Single Mongo update | Unbounded by code because Mongo update has no operation deadline and BSON can grow | Final Mongo update dominates for large documents |
+
+### 1b. errgroup Coordination Cost
+
+Current source uses one top-level errgroup, not two sequential top-level waits. `RunAllInfo.Start` launches `runGenericScans` and `runLanguageScans` concurrently at `api/securitytest/run.go:67-74`, then waits once at `api/securitytest/run.go:76`.
+
+Each group has its own nested errgroup. The critical path is:
+
+```text
+enry container lifecycle
++ max(generic scanner group duration, language scanner group duration)
++ result aggregation/final Mongo update
+```
+
+A slow scanner in the generic group does not delay language scanner startup after both wrapper goroutines are scheduled. A slow scanner in either group still delays final analysis completion because the top-level `g.Wait()` waits for both groups.
+
+### 1c. Container Start Latency
+
+Docker mode:
+
+- API call to create container: `ContainerCreate` in `api/dockers/api.go:77-91`.
+- API call to start container: `ContainerStart` in `api/dockers/api.go:93-97`.
+- The code does not explicitly wait for `running`; after `ContainerStart`, it waits for `NotRunning` at `api/dockers/api.go:99-116`.
+- Image pull happens before container creation in `api/dockers/huskydocker.go:45-51`, with a separate 15-minute retry loop at `api/dockers/huskydocker.go:89-109`.
+- Image caching is checked against the Docker daemon with `ImageIsLoaded` (`api/dockers/api.go:232-246`).
+
+Kubernetes mode:
+
+- API call to create pod: `Pods(...).Create` in `api/kubernetes/api.go:82-150`.
+- `CreatePod` returns after API acceptance, not after the pod is running.
+- `WaitPod` first waits for `Running` with `podSchedulingTimeoutInSeconds`, then waits for terminal success/failure with `testTimeOutInSeconds` (`api/kubernetes/api.go:152-230`).
+- Image pull is controlled by `ImagePullPolicy: PullIfNotPresent` at `api/kubernetes/api.go:113-118`, so cold-node pull and scheduling are counted in the scheduling timeout before `Running`.
+
+### 1d. Output Collection Latency
+
+Docker calls `ReadOutput` only after `WaitContainer` returns (`api/dockers/huskydocker.go:67-77`). `ReadOutput` then reads the entire log stream with `io.ReadAll` (`api/dockers/api.go:188-203`). Kubernetes follows the same pattern: `WaitPod` completes before `ReadOutput`, and `ReadOutput` uses `io.ReadAll` on the pod log stream (`api/kubernetes/huskykube.go:74-88`, `api/kubernetes/api.go:233-257`).
+
+The goroutine is occupied for scanner runtime plus log retrieval plus parse time. Memory use has no pre-read bound in either mode.
+
+## Phase 2 -- Concurrency And Throughput Ceiling Analysis
+
+### 2a. Goroutine Budget Per Concurrent Scan
+
+Counting goroutines spawned directly by HuskyCI scan orchestration:
+
+- Enry fails before post-enry fan-out: `1` detached `StartAnalysis` goroutine.
+- Enry succeeds but no post-enry tests: `1 + 2 = 3` goroutines.
+- All registered post-enry scanners active: `1 + 2 + 16 = 19` goroutines.
+
+The all-scanners calculation is six generic scanners (`gitauthors`, `gitleaks`, four `wizcli_*`) plus ten language scanners (`gosec`, `bandit`, `brakeman`, `safety`, `npmaudit`, `yarnaudit`, `pnpmaudit`, `spotbugs`, `tfsec`, `securitycodescan`) plus two group wrappers and the detached analysis goroutine. The HTTP request goroutine is not counted because it returns after `201`.
+
+Go's runtime multiplexes goroutines onto OS threads, so thousands of goroutines are structurally supported. The repository does not contain enough information to identify the exact N where scheduler overhead becomes measurable. Unable to verify from static analysis — requires benchmark: `BenchmarkScanGoroutineFanout` (specified in Phase 6).
+
+### 2b. Container Runtime As The True Throughput Ceiling
+
+Docker mode has no shared client or shared concurrency budget. It creates a new client per scanner (`api/dockers/huskydocker.go:37-43`) and sends concurrent create/start/wait/log calls to Docker. The daemon becomes the external serialization and rate-limit point. HuskyCI does not observe daemon queue depth.
+
+Kubernetes mode creates a clientset per scanner (`api/kubernetes/huskykube.go:49-56`) and relies on API server, scheduler, and node image cache capacity. The code does not configure `QPS`/`Burst`, and per-scanner clientsets make process-level rate control ineffective.
+
+### 2c. MongoDB As A Throughput Multiplier
+
+Hot-path MongoDB calls during an active scan:
+
+| Stage | Function | Query shape | Performance risk |
+|---|---|---|---|
+| Request preflight | `FindOneDBRepository` | `{"$and":[{"repositoryURL": url}]}` | Collection scan without `repositoryURL` index |
+| Request dedupe | `FindOneDBAnalysis` | `{"$and":[{"repositoryURL": url},{"repositoryBranch": branch}]}` | Collection scan without compound index |
+| New analysis | `InsertDBAnalysis` | insert summary | Code waits for acknowledged result/error |
+| Docker host rotation | `FindAndModifyDockerAPIAddresses` | `{}` + `$inc` | Small collection expected, but no explicit singleton guard |
+| Enry/scanner setup | `FindOneDBSecurityTest` | `{"$and":[{"name": scanner}]}` | Repeated metadata lookup per scanner |
+| Scanner list | `FindAllDBSecurityTest` | type/default or language/default | Repeated list query per scan/language |
+| Final write | `UpdateOneDBAnalysisContainer` | `{"$and":[{"RID": rid}]}` | Collection scan/update without `RID` index |
+| Polling | `FindOneDBAnalysis` | `{"$and":[{"RID": rid}]}` | O(N) polling read without `RID` index |
+
+MongoDB inserts and updates are not fire-and-forget in this code: `InsertOne` and `UpdateOne` are called and their errors are returned (`api/db/mongo/mongo.go:96-107`). Write concern is not configured in code, so the exact acknowledgement level is deployment/default-driver behavior.
+
+### 2d. Absence Of A Work Queue
+
+When scan requests arrive faster than containers can be started, HuskyCI accepts the HTTP requests first, then lets detached goroutines pile up behind Docker/Kubernetes and MongoDB. The API returns `201` before any container/pod is running. At 10x normal load, the expected failure mode is combined goroutine growth, memory growth from scanner outputs/results, and container runtime saturation. The existing same-URL/same-branch check is not a throughput control.
+
+## Phase 3 -- Memory Pressure Analysis
+
+### 3a. Per-Scan Allocation Profile
+
+Heap retained until scan completion includes:
+
+- `RunAllInfo` and its result slices (`api/securitytest/run.go:15-33`).
+- One `SecTestScanInfo` per scanner goroutine, including `Container.COutput`, `FinalOutput`, and vulnerability slices (`api/securitytest/securitytest.go:41-67`).
+- Full scanner stdout/stderr log string, created by `io.ReadAll` plus `string(body)` in Docker/Kubernetes readers.
+- Parser output structs, for example `SpotBugsOutput.SpotBugsIssue []SpotBugsIssue` (`api/securitytest/spotbugs.go:24-69`) and WizCLI nested result arrays (`api/securitytest/wizcli.go:15-123`).
+- Aggregated `HuskyCIResults` vulnerability arrays (`api/types/types.go:95-160`).
+- BSON encoding buffers during final MongoDB update.
+
+Minimum retained heap for a failed enry path is the analysis worker, enry scan metadata, and the enry output/error. Maximum heap is unbounded by code because scanner output and vulnerability arrays have no pre-parse limit. Unable to verify from static analysis — requires benchmark: `BenchmarkReadOutputBuffering` (specified in Phase 6). Unable to verify from static analysis — requires benchmark: `BenchmarkAnalysisBSONEncodingWorstCase` (specified in Phase 6).
+
+### 3b. Unbounded Stdout Buffer
+
+There is no read cap in Docker or Kubernetes log readers. The only cap is `cOutputMaxSize := 1000000` after output has already been read and usually parsed (`api/securitytest/securitytest.go:178-189`). A pathological scanner output can allocate until process memory is exhausted. For scanner output of size `S`, static code shows at least `S` for the `io.ReadAll` byte slice plus `S` for `string(body)` plus another `S` for parser conversions such as `[]byte(scanInfo.Container.COutput)`, before parsed result objects and vulnerability slices are counted.
+
+### 3c. Document Size Growth In MongoDB
+
+`types.Analysis` embeds `Containers[]`, `Codes[]`, and `HuskyCIResults` (`api/types/types.go:32-46`). MongoDB enforces a 16 MiB BSON document limit. HuskyCI has no field-level limit on number of vulnerabilities, number of files in `Codes`, or length of `errorFound`. A large scan can approach the limit even after `Container.COutput` is truncated to a short message.
+
+The `io.ReadAll` buffer and MongoDB BSON document do not share backing data in a way that avoids allocation; the code converts and copies between bytes, strings, structs, and BSON encoding.
+
+## Phase 4 -- Degradation And Saturation Behaviour
+
+### 4a. Failure Cascade Under Docker Saturation
+
+First observable symptom: accepted scans continue returning `201`, while scanner goroutines accumulate in Docker client calls and `WaitContainer` (`api/routes/analysis.go:160`, `api/dockers/huskydocker.go:53-77`, `api/dockers/api.go:99-116`). Without metrics, the only visible signals are higher API memory, goroutine count if manually profiled, and delayed `GET /analysis/:id` completion.
+
+Second failure: memory pressure increases from active scan structs and log buffers, while Docker daemon/container capacity saturates. If Docker mode hits hung containers, prior finding #2 prevents deadline recovery.
+
+Steady-state failure mode: total throughput collapse rather than graceful degradation. The service has no queue, no circuit breaker, no 429/503 admission control, and no graceful shutdown cleanup (`api/server.go:23-110`).
+
+### 4b. MongoDB Degradation Path
+
+`FindOneDBAnalysis` in request acceptance becomes dominant when collection-scan latency exceeds validation and token-check latency. The collection size where that happens cannot be derived from code because it depends on document size, RAM/cache, storage, and MongoDB deployment. The growth function is O(N) under prior finding #11. Unable to verify from static analysis — requires benchmark: `BenchmarkMongoAnalysisQueries` (specified in Phase 6).
+
+Reconnect behavior cannot be determined statically. `autoReconnect` may disconnect the shared client while in-flight operations are running (`api/db/mongo/mongo.go:76-94`), and all operations use `context.TODO()` (`api/db/mongo/mongo.go:96-174`). Unable to verify from static analysis — requires benchmark: `BenchmarkMongoReconnectDuringScan` (specified in Phase 6).
+
+### 4c. Polling Amplification
+
+MongoDB read load from polling is:
+
+```text
+reads_per_second = concurrent_scans * (1 / poll_interval_seconds)
+```
+
+At 100 concurrent scans with a 5-second poll interval, the formula is `100 * (1 / 5) = 20 reads/second`; at 1,000 concurrent scans with a 5-second interval, it is `200 reads/second`. These are formula outputs, not measured throughput estimates. Polling becomes dominant when this read rate exceeds scan-start and scan-finalization DB operation rates.
+
+`FindOneDBAnalysis` is not indexed on `RID` in source because `api/db/mongo/mongo.go` declares no indexes. The query shape is `{"RID": RID}` at `api/routes/analysis.go:53-55`, converted to `$and` in `api/db/huskydb.go:61-72`.
+
+## Phase 5 -- Observability Gap Assessment
+
+All required signals are absent today.
+
+| Signal | Performance question answered | Code location to instrument | Metric name | Type | Labels | Present? |
+|---|---|---|---|---|---|---|
+| Scan request rate | How much work is being admitted? | `api/routes/analysis.go::ReceiveRequest` entry | `huskyci_scan_requests_total` | Counter | none | Absent |
+| In-flight scan count | How much background scan work is active? | `api/analysis/analysis.go::StartAnalysis` start/end | `huskyci_inflight_scans` | Gauge | none | Absent |
+| Scan duration | What is end-to-end scan latency by runtime mode? | `run.go::Start()` through `registerFinishedAnalysis` | `huskyci_scan_duration_seconds` | Histogram | `scanner_mode` | Absent |
+| Per-scanner duration | Which scanner dominates the critical path? | Each scanner `g.Go` body in `run.go` | `huskyci_scanner_duration_seconds` | Histogram | `scanner_name` | Absent |
+| Container start latency | Is Docker/K8s startup the bottleneck? | Docker/K8s create/start or create/running | `huskyci_container_start_duration_seconds` | Histogram | `scanner_name`, `mode` | Absent |
+| Output bytes read | Are scanner logs causing memory pressure? | `dockers/api.go::ReadOutput`, `kubernetes/api.go::ReadOutput` | `huskyci_scanner_output_bytes` | Histogram | `scanner_name`, `mode` | Absent |
+| MongoDB query duration | Are DB reads/writes dominating request or scan latency? | Each DB wrapper in `huskydb.go`/`mongo.go` | `huskyci_mongodb_operation_duration_seconds` | Histogram | `operation`, `collection` | Absent |
+| Active goroutine count | Is fan-out accumulating faster than work drains? | Runtime telemetry | `huskyci_active_goroutines` | Gauge | none | Absent |
+| Docker daemon error rate | Is Docker rejecting or failing container lifecycle calls? | `ContainerCreate` / `ContainerStart` error paths | `huskyci_docker_errors_total` | Counter | `operation`, `error_type` | Absent |
+
+Minimum Prometheus dependency path to add to `api/go.mod`:
+
+```go
+github.com/prometheus/client_golang
+```
+
+Suggested metrics package:
+
+```go
+package metrics
+
+import (
+	"runtime"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	ScanRequestsTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "huskyci_scan_requests_total",
+		Help: "Total scan requests accepted by ReceiveRequest.",
+	})
+	InFlightScans = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "huskyci_inflight_scans",
+		Help: "Current number of active scan analyses.",
+	})
+	ScanDurationSeconds = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "huskyci_scan_duration_seconds",
+		Help:    "End-to-end scan duration.",
+		Buckets: prometheus.DefBuckets,
+	}, []string{"scanner_mode"})
+	ScannerDurationSeconds = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "huskyci_scanner_duration_seconds",
+		Help:    "Per-scanner execution duration.",
+		Buckets: prometheus.DefBuckets,
+	}, []string{"scanner_name"})
+	ContainerStartDurationSeconds = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "huskyci_container_start_duration_seconds",
+		Help:    "Container or pod create-to-running latency.",
+		Buckets: prometheus.DefBuckets,
+	}, []string{"scanner_name", "mode"})
+	OutputBytes = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "huskyci_scanner_output_bytes",
+		Help:    "Bytes read from scanner stdout/logs.",
+		Buckets: []float64{1024, 10240, 102400, 1048576, 10485760, 104857600},
+	}, []string{"scanner_name", "mode"})
+	MongoDurationSeconds = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "huskyci_mongodb_operation_duration_seconds",
+		Help:    "MongoDB operation duration.",
+		Buckets: prometheus.DefBuckets,
+	}, []string{"operation", "collection"})
+	ActiveGoroutines = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "huskyci_active_goroutines",
+		Help: "Current goroutine count from runtime.NumGoroutine.",
+	}, func() float64 {
+		return float64(runtime.NumGoroutine())
+	})
+	DockerErrorsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "huskyci_docker_errors_total",
+		Help: "Docker daemon errors by operation and error type.",
+	}, []string{"operation", "error_type"})
+)
+
+func init() {
+	prometheus.MustRegister(
+		ScanRequestsTotal,
+		InFlightScans,
+		ScanDurationSeconds,
+		ScannerDurationSeconds,
+		ContainerStartDurationSeconds,
+		OutputBytes,
+		MongoDurationSeconds,
+		ActiveGoroutines,
+		DockerErrorsTotal,
+	)
+}
+```
+
+Expose `/metrics` in `api/server.go`:
+
+```go
+import "github.com/prometheus/client_golang/prometheus/promhttp"
+
+echoInstance.GET("/metrics", echo.WrapHandler(promhttp.Handler()))
+```
+
+Emit scan request rate at `ReceiveRequest` entry:
+
+```go
+metrics.ScanRequestsTotal.Inc()
+```
+
+Emit in-flight scans and scan duration in `StartAnalysis`:
+
+```go
+func StartAnalysis(RID string, repository types.Repository) {
+	start := time.Now()
+	metrics.InFlightScans.Inc()
+	defer metrics.InFlightScans.Dec()
+	defer func() {
+		mode := os.Getenv("HUSKYCI_INFRASTRUCTURE_USE")
+		metrics.ScanDurationSeconds.WithLabelValues(mode).Observe(time.Since(start).Seconds())
+	}()
+	// existing body
+}
+```
+
+Emit per-scanner duration inside each scanner goroutine in `run.go`:
+
+```go
+started := time.Now()
+err := runner.startScan(scan)
+metrics.ScannerDurationSeconds.WithLabelValues(testName).Observe(time.Since(started).Seconds())
+if err != nil {
+	return err
+}
+```
+
+Emit container start latency in Docker and Kubernetes wrappers:
+
+```go
+started := time.Now()
+CID, err := d.CreateContainer(fullContainerImage, cmd)
+if err != nil { return "", "", err }
+d.CID = CID
+if err := d.StartContainer(); err != nil { return "", "", err }
+metrics.ContainerStartDurationSeconds.WithLabelValues(scannerName, "docker").Observe(time.Since(started).Seconds())
+```
+
+```go
+started := time.Now()
+podUID, err := k.CreatePod(fullContainerImage, cmd, podName, securityTestName)
+if err != nil { return "", "", err }
+_, err = k.WaitPod(podName, podSchedulingTimeoutInSeconds, timeOutInSeconds)
+metrics.ContainerStartDurationSeconds.WithLabelValues(securityTestName, "kubernetes").Observe(time.Since(started).Seconds())
+```
+
+Emit output bytes read in both `ReadOutput` implementations:
+
+```go
+body, err := io.ReadAll(out)
+metrics.OutputBytes.WithLabelValues(scannerName, "docker").Observe(float64(len(body)))
+```
+
+Emit MongoDB operation duration in each wrapper:
+
+```go
+started := time.Now()
+err := mongoHuskyCI.Conn.SearchOne(query, nil, mongoHuskyCI.AnalysisCollection, &analysisResponse)
+metrics.MongoDurationSeconds.WithLabelValues("find_one_analysis", mongoHuskyCI.AnalysisCollection).Observe(time.Since(started).Seconds())
+return analysisResponse, err
+```
+
+Emit Docker daemon error rate:
+
+```go
+if err != nil {
+	metrics.DockerErrorsTotal.WithLabelValues("container_create", classifyDockerError(err)).Inc()
+	return "", err
+}
+```
+
+## Phase 6 -- Benchmarks That Must Be Written
+
+```text
+Benchmark name: BenchmarkMongoAnalysisQueries
+File: api/db/mongo/mongo_bench_test.go
+What it measures: FindOneDBAnalysis and UpdateOneDBAnalysisContainer latency as analysis collection size grows.
+Setup: Test MongoDB instance seeded with 1k, 10k, and 100k analysis documents; run with and without proposed indexes.
+Input range: Sub-benchmarks docs=1k/10k/100k and query=RID/url_branch/url_branch_status/update_RID.
+Expected result: Indexed queries stay structurally O(1)/O(log N); unindexed current queries grow linearly.
+Regression threshold: Flag if indexed P99 exceeds 50ms or if docs examined exceeds expected index bounds.
+Gap analysis reference: prior finding #11.
+```
+
+```text
+Benchmark name: BenchmarkReadOutputBuffering
+File: api/dockers/api_bench_test.go
+What it measures: io.ReadAll throughput, allocations, and peak RSS for scanner output sizes.
+Setup: Replace Docker log stream with an io.Reader generating 1MB, 10MB, and 100MB outputs; benchmark current read-all and proposed capped reader.
+Input range: size=1MB/10MB/100MB, mode=current/capped.
+Expected result: Capped reader has bounded allocations; current implementation allocations grow linearly with output size and include byte-to-string copy cost.
+Regression threshold: Flag if capped mode allocs/op exceeds configured cap + 10% or if current mode is still used in production path.
+Gap analysis reference: unbounded stdout buffer, prior finding #3 memory consequence.
+```
+
+```text
+Benchmark name: BenchmarkScanGoroutineFanout
+File: api/securitytest/run_bench_test.go
+What it measures: Goroutine count, allocations, and completion overhead per scan at concurrent scan counts.
+Setup: Use mockRunner with configurable generic/language scanner counts and blocking no-op scanners; sample runtime.NumGoroutine before/during/after.
+Input range: concurrent_scans=1/10/50 and scanners_per_scan=1/6/16.
+Expected result: With limits, goroutine count stays near baseline + configured concurrency; current implementation grows with scans x scanners.
+Regression threshold: Flag if goroutines exceed configured limit + 20% or allocs/op grows unexpectedly after limits.
+Gap analysis reference: prior finding #3.
+```
+
+```text
+Benchmark name: BenchmarkErrgroupFanout
+File: api/securitytest/run_bench_test.go
+What it measures: errgroup fan-out overhead for mock scanner counts.
+Setup: mockRunner returns N scanners with no-op startScan; no Docker/K8s/Mongo.
+Input range: N=1..20 mock scanners, with and without errgroup.SetLimit.
+Expected result: Limited fan-out adds small coordination overhead while bounding concurrency.
+Regression threshold: Flag if SetLimit overhead exceeds 10% for N<=20 in no-op case.
+Gap analysis reference: prior finding #3.
+```
+
+```text
+Benchmark name: BenchmarkAnalysisBSONEncodingWorstCase
+File: api/analysis/analysis_bench_test.go
+What it measures: BSON encoding time and allocation size for worst-case Analysis documents.
+Setup: Build types.Analysis with max realistic Containers, Codes, and HuskyCIResults vulnerability arrays; encode with mongo-driver BSON.
+Input range: vulnerabilities=1k/10k/50k and cOutput sizes=0/1MB placeholder/errorFound prefix.
+Expected result: Encoding remains below MongoDB 16 MiB limit or fails early with a controlled error before DB update.
+Regression threshold: Flag if BSON size exceeds 14 MiB warning threshold or allocs/op exceeds document size x 3.
+Gap analysis reference: prior finding #11 document size.
+```
+
+```text
+Benchmark name: BenchmarkCheckMaliciousRepoURLConcurrent
+File: api/util/util_bench_test.go
+What it measures: Throughput and allocations of CheckMaliciousRepoURL under concurrent request validation.
+Setup: Valid and invalid repository URL corpus; compare current per-call regexp compilation with package-level compiled regexp.
+Input range: b.RunParallel with corpus sizes 10/100/1000.
+Expected result: Precompiled regex reduces allocations/op and CPU/op without changing accepted/rejected outputs.
+Regression threshold: Flag if allocs/op > 2 after precompilation or if any corpus result changes.
+Gap analysis reference: new low-severity regex CPU gap.
+```
+
+```text
+Benchmark name: BenchmarkMongoReconnectDuringScan
+File: api/db/mongo/mongo_bench_test.go
+What it measures: Mongo operation latency and error behavior while reconnect runs during active scan DB operations.
+Setup: Test MongoDB or controllable fake server; active goroutines issue FindOne/Update operations while connection is interrupted.
+Input range: concurrent_operations=1/10/50, interruption_duration=1s/5s.
+Expected result: Operations fail or recover within configured DB deadlines once deadlines are implemented.
+Regression threshold: Flag if any operation blocks beyond DB timeout or leaks goroutines.
+Gap analysis reference: reconnect latency under prior finding #11.
+```
+
+## Performance Strengths
+
+- **Request acceptance is asynchronous.** `ReceiveRequest` returns after spawning `StartAnalysis` (`api/routes/analysis.go:160-162`), so HTTP clients are not held for full scanner duration.
+- **Generic and language scanner groups start concurrently.** The top-level errgroup launches both group functions before waiting (`api/securitytest/run.go:67-76`).
+- **Kubernetes scanner execution has explicit timeout watches.** `WaitPod` uses `TimeoutSeconds` for scheduling and execution phases (`api/kubernetes/api.go:152-230`).
+- **Kubernetes image policy uses node cache when available.** `ImagePullPolicy: core.PullIfNotPresent` is set in `api/kubernetes/api.go:113-118`.
+- **Concurrent result aggregation is mutex-protected.** `RunAllInfo.mu` guards appends and vulnerability aggregation in `api/securitytest/run.go:114-122` and `api/securitytest/run.go:160-179`.
+- **Stored container output has a post-read cap.** `prepareContainerAfterScan` replaces `COutput` when it exceeds 1,000,000 bytes (`api/securitytest/securitytest.go:178-189`). This does not solve pre-read memory pressure, but it reduces MongoDB document growth for successful paths.
+- **MongoDB writes are not fire-and-forget in code.** `InsertOne` and `UpdateOne` return errors and callers propagate them (`api/db/mongo/mongo.go:96-107`).
+- **MongoDB auto-reconnect exists as a limited recovery mechanism.** `autoReconnect` pings every second and reconnects on error (`api/db/mongo/mongo.go:76-94`). This is useful for transient connectivity, but its latency impact on in-flight queries is not statically verifiable and is covered by `BenchmarkMongoReconnectDuringScan`.
+- **CI runs the race detector.** `.github/workflows/ci.yaml:36-38` runs `go test -race -count=1 ./...`, which can catch performance-relevant data races in concurrent aggregation.
+
+## Prioritised Remediation Roadmap
+
+### Immediate (0-30 days)
+
+| Item | Effort | Expected throughput impact | Benchmark verification |
+|---|---:|---|---|
+| Add global scan/scanner concurrency limits and return 429/503 when saturated | 3-5 days | Prevents total saturation from bursty request traffic | `BenchmarkScanGoroutineFanout`, `BenchmarkErrgroupFanout` |
+| Fix Docker `WaitContainer` timeout and cleanup on timeout | 1-2 days | Prevents indefinite Docker-mode resource retention | Integration timeout test; no benchmark needed |
+| Cap Docker and Kubernetes log reads before `io.ReadAll`/string conversion | 2-3 days | Prevents OOM from large scanner output | `BenchmarkReadOutputBuffering` |
+| Add MongoDB indexes on `analysis.RID`, active URL/branch/status, and `repository.repositoryURL` | 1-2 days | Restores hot-path query growth from O(N) toward indexed lookup behavior | `BenchmarkMongoAnalysisQueries` |
+| Add minimal Prometheus `/metrics` with request, in-flight, duration, output bytes, Mongo, goroutine, and Docker error metrics | 3-5 days | Makes saturation visible before outage | Operational validation plus benchmark labels |
+
+### Near-term (30-90 days)
+
+| Item | Effort | Expected throughput impact | Benchmark verification |
+|---|---:|---|---|
+| Share Docker clients per host and Kubernetes clientset per process with explicit QPS/Burst | 1 week | Reduces client churn and enables runtime-level request budgeting | Docker/K8s burst benchmarks |
+| Move scanner metadata reads out of the hot path into startup cache | 3-5 days | Removes repeated DB reads per scanner | `BenchmarkMongoAnalysisQueries` |
+| Split large scanner findings from the analysis summary document | 1-2 weeks | Avoids BSON 16 MiB cliff and reduces final update latency | `BenchmarkAnalysisBSONEncodingWorstCase` |
+| Add per-operation MongoDB contexts with deadlines | 3-5 days | Bounds latency during collection scans/reconnect/server stalls | `BenchmarkMongoReconnectDuringScan` |
+| Add server-side polling controls (`Retry-After`, rate limits, optional long polling) | 1 week | Reduces read amplification from clients | `BenchmarkMongoAnalysisQueries` plus load test |
+
+### Long-term (90+ days)
+
+| Item | Effort | Expected throughput impact | Benchmark verification |
+|---|---:|---|---|
+| Introduce durable scan queue with workers and explicit capacity policy | 3-6 weeks | Converts overload from collapse to controlled queueing/rejection | End-to-end load benchmark |
+| Add OpenTelemetry traces from request acceptance through scanner lifecycle and MongoDB operations | 2-4 weeks | Enables P95/P99 root-cause attribution | Trace completeness checks |
+| Add a stale-analysis and orphaned-container/pod reaper | 1-2 weeks | Recovers capacity after restart or crash | Integration failure-injection tests |
+| Establish performance benchmark suite in CI/nightly runs | 2-3 weeks | Prevents regression in fan-out, Mongo, output buffering, and BSON encoding | All Phase 6 benchmarks |
+| Revisit result storage model and retention/TTL policy | 2-4 weeks | Controls long-term collection size and polling latency | `BenchmarkMongoAnalysisQueries`, storage growth checks |
+
+## External Primary References Consulted
+
+- Go documentation: goroutines are multiplexed onto OS threads.
+- MongoDB manual: `COLLSCAN`, documents examined, and 16 MiB BSON document limit.
+- Kubernetes `client-go/rest` package documentation: `DefaultQPS = 5.0`, `DefaultBurst = 10`.
+- Prometheus `client_golang` package documentation: Counter, Gauge, HistogramVec, and `promhttp.Handler`.

--- a/docs/assessments/wizcli-performance-assessment-01.md
+++ b/docs/assessments/wizcli-performance-assessment-01.md
@@ -1,0 +1,155 @@
+# HuskyCI - WizCLI Performance Assessment
+
+## Summary
+
+The three requested line anchors map to `wizcli_iac`, `wizcli_sast`, and `wizcli_vulns`; all three use `939030204144.dkr.ecr.us-east-1.amazonaws.com/huskyci-wiz:f793155-amd64`, are `type: Generic`, `default: true`, `timeOutInSeconds: 600`, and run `wizcli scan dir ./code` against the repository root with different `--disabled-scanners` sets. The repo also contains a default `wizcli_secrets` entry with the same execution profile; per scope, this assessment focuses on the three requested variants and notes where the fourth would worsen multipliers.
+
+WizCLI differs from gosec/bandit because the dominant variable is not local CPU or filesystem traversal; it is `wizcli auth` plus cloud scan/upload/result retrieval inside each container. That network-dependent work is wrapped by HuskyCI as if it were a local scanner command.
+
+The highest-impact improvement without architectural change is to add config-level changed-file preflight guards before `wizcli auth`, so README-only or unrelated PRs emit an empty valid result without paying auth/upload/scan cost. Add command-level timeout wrappers around `wizcli auth` and `wizcli scan` at the same time.
+
+## Confirmed findings
+
+### Three default Generic WizCLI variants scan the same root independently
+
+**Severity:** High
+
+**Evidence:** `wizcli_iac`, `wizcli_sast`, and `wizcli_vulns` all run `wizcli scan dir ./code` in `api/config.yaml:675`, `api/config.yaml:774`, and `api/config.yaml:812`. All are `type: Generic`, `default: true`, `timeOutInSeconds: 600` at `api/config.yaml:717`, `api/config.yaml:791`, and `api/config.yaml:828`.
+
+**Cross-reference:** Gap #3 plus wizcli-specific duplication
+
+**Impact:** They enter the same `runGenericScans` errgroup and start without internal sequencing, so auth + repository clone/upload + scan setup are paid three times in parallel. `wizcli_secrets` at `api/config.yaml:573` would make this four default WizCLI containers in production.
+
+**Recommendation:** Collapse duplicate root traversal where possible, or add pre-auth changed-file guards in each WizCLI `cmd`.
+
+**Verifiable by:** Static analysis
+
+### Each variant authenticates separately
+
+**Severity:** High
+
+**Evidence:** The three scoped entries each run `wizcli auth --id '%WIZ_CLIENT_ID%' --secret '%WIZ_CLIENT_SECRET%'` before scanning: `api/config.yaml:670`, `api/config.yaml:744`, `api/config.yaml:807`.
+
+**Cross-reference:** wizcli-specific
+
+**Impact:** A scan that triggers all three scoped variants implies at least `3x` auth round-trip cost versus `1x` if one WizCLI container authenticated once and ran the enabled scan modes. The exact Wiz API request count per auth cannot be verified statically.
+
+**Recommendation:** Short term: skip auth when changed files are irrelevant. Long term: one WizCLI orchestration container or shared token cache.
+
+**Verifiable by:** Static analysis for separate auth commands; benchmark or WizCLI docs for exact round-trip count
+
+### Docker mode does not enforce the configured 600-second WizCLI timeout
+
+**Severity:** Critical
+
+**Evidence:** `timeOutInSeconds: 600` is configured for all three scoped variants, but Docker `WaitContainer(timeOutInSeconds int)` never uses the parameter and waits on `ContainerWait(context.Background(), ...)`: `api/dockers/api.go:100`. K8s does enforce `TimeoutSeconds` and removes the pod on timeout at `api/kubernetes/api.go:198`.
+
+**Cross-reference:** Bug #2
+
+**Impact:** In Docker mode, a Wiz auth or cloud scan hang can hold the scanner goroutine indefinitely and delay final analysis persistence. Language scanners are started concurrently by the top-level errgroup at `api/securitytest/run.go:67`, but final completion still waits.
+
+**Recommendation:** Fix Docker `WaitContainer` with `context.WithTimeout`, stop/remove timed-out containers, and preserve scanner error output.
+
+**Verifiable by:** Static analysis; Docker-mode timeout test
+
+### Delta scanning does not suppress WizCLI execution
+
+**Severity:** High
+
+**Evidence:** Generic scanners are selected by `{"type": "Generic", "default": true}` without language or changed-file filtering at `api/securitytest/run.go:279`. `ChangedFiles` is passed into the command template, but `runGenericScans` still launches each default generic scanner at `api/securitytest/run.go:94`. `wizcli_vulns` has no `HUSKYCI_DELTA_SCAN` sparse-checkout branch at `api/config.yaml:805`.
+
+**Cross-reference:** wizcli-specific
+
+**Impact:** A PR that changes only README or unrelated source still launches all default WizCLI variants unless disabled by env/config; for WizCLI that means avoidable network auth and cloud scan work, not just local CPU.
+
+**Recommendation:** Add config-level skip guards before auth, and near-term move scanner selection into `run.go` using `changedFiles` and scanner scope metadata.
+
+**Verifiable by:** Static analysis
+
+### WizCLI output is fully buffered and parsed after unbounded log reads
+
+**Severity:** Critical
+
+**Evidence:** Docker reads logs with `io.ReadAll` at `api/dockers/api.go:197`; K8s does the same at `api/kubernetes/api.go:247`. Wiz parsing then calls `json.Unmarshal([]byte(output), &report)` at `api/securitytest/wizcli.go:379`. The 1 MB truncation happens only later in `prepareContainerAfterScan` at `api/securitytest/securitytest.go:180`.
+
+**Cross-reference:** Probable `io.ReadAll` gap
+
+**Impact:** Cloud-enriched Wiz output is read fully into memory, converted to string, then copied again for JSON parsing. With three scoped variants in parallel, worst-case buffer pressure is multiplied.
+
+**Recommendation:** Add bounded log readers before `COutput`, then stream or size-limit Wiz JSON parsing.
+
+**Verifiable by:** Static analysis; large-output benchmark
+
+### Wiz image is tag-pinned, not digest-pinned
+
+**Severity:** Medium
+
+**Evidence:** Each scoped variant uses `imageTag: "f793155-amd64"` rather than an `@sha256:` digest: `api/config.yaml:650`, `api/config.yaml:724`, `api/config.yaml:798`. Docker/K8s image construction appends `image:tag`, not digest form, at `api/dockers/huskydocker.go:23`.
+
+**Cross-reference:** Gap #6
+
+**Impact:** Static analysis cannot prove registry tag immutability. If the tag is overwritten, WizCLI binary behavior and performance can change without config diffs.
+
+**Recommendation:** Support digest image references or enforce immutable registry tags and record `extraInfo.clientVersion` in scan metadata.
+
+**Verifiable by:** Static analysis plus registry policy check
+
+## Probable findings
+
+### Wiz API outage behavior is not characterized
+
+**Severity estimate:** Critical
+
+**Indicators:** Commands rely on WizCLI's own behavior for `auth` and `scan`; Docker mode has no external timeout. `analyzeWizCLI` recognizes only `ERROR_AUTH_WIZCLI` and `ERROR_RUNNING_WIZCLI_SCAN` at `api/securitytest/wizcli.go:128`.
+
+**Cannot verify because:** Static analysis does not show whether WizCLI retries, exits quickly, or hangs on unreachable Wiz APIs.
+
+**Investigation:** Run Docker and K8s scans with Wiz API egress blocked; record wall-clock, stdout/stderr, exit codes, and whether sentinels are emitted.
+
+### Timeout value is not demonstrably calibrated for cloud latency
+
+**Severity estimate:** Medium
+
+**Indicators:** All scoped variants use the same flat `600` seconds with no stage budget for auth, upload, scan processing, or result retrieval.
+
+**Cannot verify because:** Requires measured WizCLI latency distributions and/or WizCLI retry documentation.
+
+**Investigation:** Add per-stage timing around auth and scan in a test image or wrapper, then set timeout from observed percentiles and failure-mode policy.
+
+### Server-side deduplication cannot be assumed
+
+**Severity estimate:** Medium
+
+**Indicators:** HuskyCI runs independent containers with independent auth and independent `/tmp/wizResult.json` files.
+
+**Cannot verify because:** Whether Wiz SaaS deduplicates uploads/results across independent CLI invocations requires Wiz documentation or measurement.
+
+**Investigation:** Run the three modes on the same repo with correlation IDs and inspect Wiz-side scan records.
+
+## Strengths
+
+- The integration uses a shared parser for all WizCLI variants via `securityTestAnalyze` mapping at `api/securitytest/securitytest.go:32`.
+- Parser coverage is broad: libraries, OS packages, secrets, data findings, IaC, SAST, malware, AI models, and software supply chain are modeled in `api/securitytest/wizcli.go:18`.
+- Existing tests cover empty JSON, invalid JSON, no findings, auth failure, scan failure, and several result categories in `api/securitytest/wizcli_test.go:35`.
+- K8s mode has a real runtime timeout and deletes timed-out pods at `api/kubernetes/api.go:225`.
+- Wiz commands write JSON to `/tmp/wizResult.json` and suppress normal scan stdout, reducing noisy container logs.
+
+## Prioritized improvements
+
+### Immediate (0-30 days)
+
+- Add changed-file pre-auth guards in the three WizCLI `cmd` templates. Effort: M. Impact: High. Addresses duplicate execution and delta waste.
+- Add command-level auth/scan timeout sentinels in `config.yaml`. Effort: S-M. Impact: High in Docker mode. Addresses outage behavior until Bug #2 is fixed.
+- Add `wizcli.go` input-size guard before `json.Unmarshal` and tests for large output, auth failure, timeout text, and real IaC/SAST fixtures. Effort: S. Impact: Medium. Addresses parser and memory test gaps.
+
+### Near-term (30-90 days)
+
+- Fix Docker timeout enforcement and cleanup in `api/dockers/api.go`. Effort: M. Impact: Critical. Addresses Bug #2 for WizCLI.
+- Add bounded log reading for Docker and K8s before storing `COutput`. Effort: M. Impact: Critical. Addresses unbounded output amplification.
+- Add scanner selection logic in `run.go` so Generic cloud scanners can skip based on changed files and scanner scope. Effort: M-L. Impact: High.
+
+### Long-term (90+ days)
+
+- Replace separate WizCLI variant containers with one WizCLI orchestration container that authenticates once and runs required modes. Effort: L. Impact: High.
+- Stream Wiz results into parser/storage with size limits and per-stage timing. Effort: L. Impact: Critical.
+- Add cloud-scanner telemetry: auth duration, scan duration, output bytes, timeout reason, and WizCLI version. Effort: M-L. Impact: High.


### PR DESCRIPTION
 ## Summary

  Adds a tiered safety net of test files that pin down behavioral contracts the
  codebase currently lacks coverage for. The goal is to make the open issues
  (concurrency cap, panic recovery, finalization order, SSRF hardening,
  exit-code refactor) safe to land — each fix can be verified by removing a
  `t.Skip` line and watching the test go green.

  No production code changes. Tests only.

  ### Why now

  Several upcoming PRs will touch high-blast-radius areas:

  - `run.go` orchestration (finalization order bug #8, panic recovery gap #7,
    concurrency limit gap #3)
  - `CheckMaliciousRepoURL` SSRF hardening (gap #10)
  - Client exit-code refactor (190 contract is currently a literal inside
    `os.Exit` calls in `main()`)
  - Parser robustness (a panicking JSON parser today crashes the API)

  Each of these has *zero* regression coverage on the desired post-fix behavior.
  This PR establishes the safety net before the fixes land, so reviewers and
  authors of those PRs can verify their work against a written contract.

  ## What's added

  | File | Purpose | Tier |
  |------|---------|------|
  | `api/securitytest/orchestration_test.go` | 5 tests via existing `mockRunner`: 1 baseline + 4 skipped tests pinning desired post-fix behavior for bugs #8
  ×2, #7, #3 | Tier 1 — orchestration |
  | `api/util/validation_test.go` | Table-driven coverage for the three malicious-input validators; SSRF/path-traversal rows in skipped subtests | Tier 3 —
  input validation |
  | `client/analysis/exitcode_test.go` | 3 tests driving `prepareAllSummary` to pin the 190 exit-code contract | Tier 2 — client contract |
  | `api/securitytest/gosec_test.go` + 3 fixtures | Parser regression template (high_vuln / no_vuln / malformed JSON) | Tier 4 — parser |

  ### Skip discipline

  Every skipped test has a message naming the exact file and lines that need to
  be fixed before the skip can be removed. Examples:

  ```go
  t.Skip("Bug #8 — remove this Skip after setToAnalysis/setFinalResult order is fixed in run.go:65-81")
  t.Skip("Gap #7 — remove this Skip after defer recover() is added to g.Go bodies in run.go:100-124 and run.go:149-181")
  t.Skip("Gap #3 — remove this Skip after errgroup.SetLimit is added in run.go")
  t.Skip("Gap #10 — remove this Skip after CheckMaliciousRepoURL blocks RFC1918, link-local, loopback, file://, and credentials-in-URL")

  Once the corresponding fix lands, the developer deletes one line and the test
  asserts the new behavior — no test code changes required.

  Notable implementation choices

  - No new dependencies. Stdlib testing only. Neither module has testify;
  this matches every existing parser test.
  - Reused mockRunner from api/securitytest/runner.go rather than writing
  a new mock. Same pattern as the existing run_test.go.
  - exitcode_test.go placed in client/analysis/, not client/, because
  the unit-of-decision (prepareAllSummary) is unexported and lives in
  package analysis. Tests drive that function and assert on the
  types.FoundVuln / types.FoundInfo globals that main() reads.
  - validation_test.go calls log.InitLog in init() because
  CheckMaliciousRepoBranch dereferences log.Logger on the invalid-input
  path; without init the test would nil-deref before reaching the assertion.
  - Testability gap documented in TestExitDecision_NonZeroNotOneNinetyWhenAPIUnreachable:
  API-error os.Exit(1) calls live inline in main() (lines 32, 44, 55, 82, 98).
  The test pins the contract invariant apiErrorExit != vulnFoundExit and
  adds a // PROBABLE GAP: comment recommending a future decideExitCode
  helper extraction.

  Test plan

  - [x] cd api && go vet ./securitytest/... ./util/...
  - [x] cd api && go test -race -count=1 ./securitytest/... ./util/...
  - [x] cd client && go vet ./...
  - [x] cd client && go test -race -count=1 ./...
  - [x] Confirm 4 expected SKIP outputs (Bug #8 ×2, Gap #7, Gap #3) plus 3 gap subtests in validation_test (Gap #10, branch path-traversal, changed-files
  absolute/traversal)
  - [x] Confirm no data races reported by -race
  - [ ] Reviewer: spot-check that each t.Skip message points to a real line/function in the named file

  Files changed

  api/securitytest/gosec_test.go                    | 129 +++++
  api/securitytest/orchestration_test.go            | 283 ++++++++++
  api/securitytest/testdata/gosec/high_vuln.json    |  28 +
  api/securitytest/testdata/gosec/malformed.json    |   4 +
  api/securitytest/testdata/gosec/no_vuln.json      |   9 +
  api/util/validation_test.go                       | 211 ++++++++
  client/analysis/exitcode_test.go                  | 127 ++++++

  Out of scope

  Deliberately not in this PR (separate scopes per the planning doc):
  - api/dockers/ integration tests (require real daemon)
  - api/routes/ HTTP handler tests 
  - api/db/ database layer tests
  - api/token/ timing oracle tests
  - cli/ command tests
  - Remaining per-tool parser tests (bandit, brakeman, npmaudit, spotbugs, etc.) —
  gosec_test.go is the template for those follow-ups

  ---