### PR TITLE
feat: #60 - Add BenchmarkReadOutputBuffering + BenchmarkCheckMaliciousRepoURLConcurrent

### DIFF
--- a/api/dockers/readoutput_bench_test.go
+++ b/api/dockers/readoutput_bench_test.go
@@ -1,0 +1,176 @@
+// Copyright 2026 Globo.com authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package dockers
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"math/rand"
+	"runtime"
+	"testing"
+
+	"github.com/githubanotaai/huskyci-api/api/util"
+)
+
+// generateBytes produces a deterministic byte slice of the given size using a
+// fixed seed. This keeps benchmarks reproducible and free of Docker
+// dependencies.
+func generateBytes(size int) []byte {
+	rng := rand.New(rand.NewSource(42))
+	buf := make([]byte, size)
+	for i := range buf {
+		buf[i] = byte(rng.Intn(256))
+	}
+	return buf
+}
+
+// BenchmarkReadOutputBuffering measures io.ReadAll throughput, allocations,
+// and peak RSS for scanner output sizes. It compares two modes:
+//
+//   - Capped: uses util.ReadBoundedScannerOutput (io.LimitReader +
+//     io.ReadAll), which is the current production path since #48.
+//   - Naive: reads into a bytes.Buffer then casts to string,
+//     characterising the unbounded path for comparison.
+//
+// Sizes: 1 MB, 10 MB, 100 MB.
+// No Docker daemon is required — all readers are generated in-memory.
+func BenchmarkReadOutputBuffering(b *testing.B) {
+	sizes := []struct {
+		name  string
+		bytes int
+	}{
+		{"1MB", 1 << 20},
+		{"10MB", 10 << 20},
+		{"100MB", 100 << 20},
+	}
+
+	for _, sz := range sizes {
+		data := generateBytes(sz.bytes)
+
+		b.Run("Size="+sz.name, func(b *testing.B) {
+			b.Run("Mode=Capped", func(b *testing.B) {
+				b.ReportAllocs()
+
+				for b.Loop() {
+					reader := bytes.NewReader(data)
+					_, err := util.ReadBoundedScannerOutput(reader)
+					if err != nil {
+						b.Fatalf("unexpected capped error at %s: %v", sz.name, err)
+					}
+				}
+
+				// Report peak RSS via runtime.ReadMemStats.
+				var m runtime.MemStats
+				runtime.ReadMemStats(&m)
+				b.ReportMetric(float64(m.Sys)/1024/1024, "Sys-MB")
+			})
+
+			b.Run("Mode=Naive", func(b *testing.B) {
+				b.ReportAllocs()
+
+				for b.Loop() {
+					reader := bytes.NewReader(data)
+					var buf bytes.Buffer
+					if _, err := io.Copy(&buf, reader); err != nil {
+						b.Fatalf("unexpected naive error at %s: %v", sz.name, err)
+					}
+					_ = buf.String()
+				}
+
+				var m runtime.MemStats
+				runtime.ReadMemStats(&m)
+				b.ReportMetric(float64(m.Sys)/1024/1024, "Sys-MB")
+			})
+		})
+	}
+}
+
+// TestReadOutputBufferingCorrectness verifies the bounded reader used by
+// Docker.ReadOutput (via util.ReadBoundedScannerOutput). It checks:
+//
+//	a) All bytes are preserved for sizes within the limit.
+//	b) Output beyond MaxScannerOutputBytes returns ErrScannerOutputTooLarge.
+//	c) Capped allocations stay under cap + 10%.
+func TestReadOutputBufferingCorrectness(t *testing.T) {
+	t.Parallel()
+
+	t.Run("byte preservation", func(t *testing.T) {
+		t.Parallel()
+
+		sizes := []int{1024, 1 << 20} // 1 KB, 1 MB
+		for _, size := range sizes {
+			expected := generateBytes(size)
+			result, err := util.ReadBoundedScannerOutput(bytes.NewReader(expected))
+			if err != nil {
+				t.Fatalf("unexpected error for size %d: %v", size, err)
+			}
+			if result != string(expected) {
+				t.Fatalf("bytes not preserved for size %d: got %d bytes, want %d",
+					size, len(result), len(expected))
+			}
+		}
+	})
+
+	t.Run("byte preservation at cap boundary", func(t *testing.T) {
+		// Exactly MaxScannerOutputBytes should pass.
+		size := util.MaxScannerOutputBytes
+		expected := generateBytes(size)
+		result, err := util.ReadBoundedScannerOutput(bytes.NewReader(expected))
+		if err != nil {
+			t.Fatalf("unexpected error at cap boundary: %v", err)
+		}
+		if result != string(expected) {
+			t.Fatalf("bytes not preserved at cap boundary: got %d, want %d",
+				len(result), len(expected))
+		}
+	})
+
+	t.Run("ErrScannerOutputTooLarge at limit+1", func(t *testing.T) {
+		// One byte beyond MaxScannerOutputBytes must return
+		// ErrScannerOutputTooLarge.
+		size := util.MaxScannerOutputBytes + 1
+		data := generateBytes(size)
+		_, err := util.ReadBoundedScannerOutput(bytes.NewReader(data))
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !errors.Is(err, util.ErrScannerOutputTooLarge) {
+			t.Fatalf("expected ErrScannerOutputTooLarge, got %v", err)
+		}
+	})
+
+	t.Run("capped allocations bounded", func(t *testing.T) {
+		// For an input at the cap boundary, the capped reader must
+		// produce the correct output and not leak unbounded memory.
+		// io.ReadAll doubles its internal buffer, so cumulative
+		// B/op (benchmark) will be ~3.4x the output size. Here we
+		// verify the live heap after GC stays proportional to the
+		// output (≤ 2.5x cap, accounting for the final io.ReadAll
+		// buffer + string copy overhead).
+		size := util.MaxScannerOutputBytes
+		data := generateBytes(size)
+
+		runtime.GC()
+		var m1, m2 runtime.MemStats
+		runtime.ReadMemStats(&m1)
+
+		result, err := util.ReadBoundedScannerOutput(bytes.NewReader(data))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		_ = result // keep alive so GC does not reclaim
+
+		// Force GC to collect intermediate io.ReadAll buffers.
+		runtime.GC()
+		runtime.ReadMemStats(&m2)
+		allocDelta := int64(m2.Alloc) - int64(m1.Alloc)
+		maxAllowed := int64(float64(size) * 2.5)
+
+		if allocDelta > maxAllowed {
+			t.Errorf("capped live heap delta %d exceeds 2.5x cap (%d)", allocDelta, maxAllowed)
+		}
+	})
+}

--- a/api/util/util_bench_test.go
+++ b/api/util/util_bench_test.go
@@ -1,0 +1,179 @@
+// Copyright 2026 Globo.com authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package util_test
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/githubanotaai/huskyci-api/api/util"
+)
+
+// urlPattern is the same regex used by util.validRepoURL, kept here as a
+// constant for the per-call benchmark variant so we can quantify the cost
+// of compiling this pattern on every call.
+const urlPattern = `((git|ssh|http(s)?)|((git@|gitlab@)[\w\.]+))(:(//)?)([\w\.@\:/\-~]+)(\.git)(/)?`
+
+// corpusURLs returns a deterministic slice of valid and invalid URLs
+// constructed by interleaving the fixed test inputs to reach the requested
+// count. Valid URLs cycle through the valid set; invalid through the invalid
+// set; they alternate so the corpus exercises both paths evenly.
+func corpusURLs(n int) []string {
+	valid := []string{
+		"https://github.com/org/repo.git",
+		"git@github.com:org/repo.git",
+		"ssh://git@github.com/org/repo.git",
+	}
+	invalid := []string{
+		"http://localhost/repo.git",
+		"file:///etc/passwd",
+		"https://user:token@github.com/org/repo.git",
+	}
+
+	urls := make([]string, n)
+	for i := range urls {
+		if i%2 == 0 {
+			urls[i] = valid[i%len(valid)]
+		} else {
+			urls[i] = invalid[i%len(invalid)]
+		}
+	}
+	return urls
+}
+
+// perCallCheckMaliciousRepoURL is a functional copy of
+// util.CheckMaliciousRepoURL that compiles the URL regex on every call
+// instead of using the package-level precompiled regex. It exists solely
+// for benchmarking — it does NOT modify production code and is never
+// called from outside this test file.
+func perCallCheckMaliciousRepoURL(repositoryURL string) (string, error) {
+	re := regexp.MustCompile(urlPattern)
+	if !re.MatchString(repositoryURL) {
+		return "", fmt.Errorf("invalid URL format: %s", repositoryURL)
+	}
+	sanitized := re.FindString(repositoryURL)
+	if strings.HasPrefix(sanitized, "git@") || strings.HasPrefix(sanitized, "gitlab@") {
+		return sanitized, nil
+	}
+
+	parsed, err := url.Parse(sanitized)
+	if err != nil {
+		return "", err
+	}
+	switch parsed.Scheme {
+	case "git", "http", "https", "ssh":
+	default:
+		return "", fmt.Errorf("invalid repository URL scheme: %s", parsed.Scheme)
+	}
+	if parsed.User != nil {
+		return "", fmt.Errorf("repository URL must not contain credentials")
+	}
+	if isUnsafeRepoHostBench(parsed.Hostname()) {
+		return "", fmt.Errorf("repository URL points to a blocked host")
+	}
+	return sanitized, nil
+}
+
+// isUnsafeRepoHostBench is a copy of util.isUnsafeRepoHost for benchmark use
+// since the original is unexported.
+func isUnsafeRepoHostBench(host string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	if host == "" || host == "localhost" || strings.HasSuffix(host, ".localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	return ip.IsPrivate() || ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified()
+}
+
+// BenchmarkCheckMaliciousRepoURLConcurrent measures throughput and
+// allocations of CheckMaliciousRepoURL under parallel validation. It
+// compares two variants:
+//
+//   - Compiled: calls util.CheckMaliciousRepoURL, which uses the
+//     package-level precompiled regex (current production path).
+//   - PerCall: calls perCallCheckMaliciousRepoURL, which recompiles the
+//     identical pattern on every call (hypothetical worst-case used only
+//     for comparison).
+//
+// Corpus sizes: 10, 100, 1000 URLs.
+func BenchmarkCheckMaliciousRepoURLConcurrent(b *testing.B) {
+	sizes := []int{10, 100, 1000}
+
+	for _, n := range sizes {
+		urls := corpusURLs(n)
+
+		b.Run(fmt.Sprintf("Corpus=N=%d", n), func(b *testing.B) {
+			b.Run("Variant=Compiled", func(b *testing.B) {
+				b.ReportAllocs()
+				b.RunParallel(func(pb *testing.PB) {
+					i := 0
+					for pb.Next() {
+						_, _ = util.CheckMaliciousRepoURL(urls[i%len(urls)])
+						i++
+					}
+				})
+			})
+
+			b.Run("Variant=PerCall", func(b *testing.B) {
+				b.ReportAllocs()
+				b.RunParallel(func(pb *testing.PB) {
+					i := 0
+					for pb.Next() {
+						_, _ = perCallCheckMaliciousRepoURL(urls[i%len(urls)])
+						i++
+					}
+				})
+			})
+		})
+	}
+}
+
+// TestCheckMaliciousRepoURLCorpusBehavior verifies that the compiled
+// (util.CheckMaliciousRepoURL) and per-call
+// (perCallCheckMaliciousRepoURL) variants produce identical results for
+// every URL in the full corpus — same accepted/rejected verdict and same
+// sanitized output.
+func TestCheckMaliciousRepoURLCorpusBehavior(t *testing.T) {
+	t.Parallel()
+
+	allURLs := []string{
+		"https://github.com/org/repo.git",
+		"git@github.com:org/repo.git",
+		"ssh://git@github.com/org/repo.git",
+		"http://localhost/repo.git",
+		"file:///etc/passwd",
+		"https://user:token@github.com/org/repo.git",
+	}
+
+	for _, raw := range allURLs {
+		t.Run(raw, func(t *testing.T) {
+			t.Parallel()
+
+			compiledSan, compiledErr := util.CheckMaliciousRepoURL(raw)
+			perCallSan, perCallErr := perCallCheckMaliciousRepoURL(raw)
+
+			// Both must agree on whether the URL was accepted.
+			compiledPass := compiledErr == nil
+			perCallPass := perCallErr == nil
+			if compiledPass != perCallPass {
+				t.Errorf("mismatched verdict for %q: compiled=%v perCall=%v",
+					raw, compiledPass, perCallPass)
+			}
+
+			// When accepted, sanitized output must match.
+			if compiledPass && compiledSan != perCallSan {
+				t.Errorf("sanitized mismatch for %q:\ncompiled: %q\nperCall: %q",
+					raw, compiledSan, perCallSan)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Implements GitHub issue #60 — adds performance benchmark coverage for scanner output buffering and concurrent URL validation.

## Changes

### US-001: BenchmarkReadOutputBuffering (`api/dockers/readoutput_bench_test.go`)
- Non-integration benchmark (no Docker required, no build tag)
- Measures `io.ReadAll` throughput, allocations, and peak RSS for 1MB/10MB/100MB outputs
- Compares capped mode (`util.ReadBoundedScannerOutput`) vs naive uncapped mode
- Companion correctness test verifies byte preservation, overflow error, and alloc bounds

### US-002: BenchmarkCheckMaliciousRepoURLConcurrent (`api/util/util_bench_test.go`)
- Concurrent benchmark using `b.RunParallel` at corpus sizes 10/100/1000
- Compares package-level compiled regex against hypothetical per-call compilation
- Companion test verifies both variants produce identical results across the corpus

### Verification

```
cd api && go test -run '^$' -bench BenchmarkReadOutputBuffering -benchtime=1x ./dockers   # PASS
cd api && go test -run '^$' -bench BenchmarkCheckMaliciousRepoURLConcurrent -benchtime=1x ./util  # PASS
cd api && go test -run 'TestReadOutputBufferingCorrectness|TestCheckMaliciousRepoURLCorpusBehavior' ./dockers ./util  # PASS
cd api && go vet ./dockers ./util  # CLEAN
```

## Dependencies
- #48 (bounded reader) and #43 (precompiled regex) are already present on `main` — this PR only adds benchmark coverage, no production code changes.

Closes #60