### PR TITLE
feat: US-001 - Upgrade golang.org/x/net from v0.54.0 to v0.55.0

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/spf13/viper v1.15.0
 	go.mongodb.org/mongo-driver v1.17.2
 	golang.org/x/crypto v0.51.0
-	golang.org/x/net v0.54.0
 	golang.org/x/sync v0.20.0
 	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22
 	k8s.io/api v0.27.1
@@ -75,8 +74,9 @@ require (
 	github.com/xdg-go/stringprep v1.0.4 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
 	golang.org/x/mod v0.35.0 // indirect
+	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.8.0 // indirect
-	golang.org/x/sys v0.44.0 // indirect
+	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/term v0.43.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/time v0.3.0 // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -408,8 +408,8 @@ golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96b
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
-golang.org/x/net v0.54.0 h1:2zJIZAxAHV/OHCDTCOHAYehQzLfSXuf/5SoL/Dv6w/w=
-golang.org/x/net v0.54.0/go.mod h1:Sj4oj8jK6XmHpBZU/zWHw3BV3abl4Kvi+Ut7cQcY+cQ=
+golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
+golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -484,8 +484,8 @@ golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
-golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
+golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=

--- a/progress-c841496d-7b3e-4c2d-b3a1-75d6af87ed59.txt
+++ b/progress-c841496d-7b3e-4c2d-b3a1-75d6af87ed59.txt
@@ -1,0 +1,132 @@
+# Progress Log
+Run: c841496d-7b3e-4c2d-b3a1-75d6af87ed59
+Task: Implement GitHub issue #87 in huskyci-api — Upgrade golang.org/x/net to fix GO-2026-5026
+Started: 2026-06-19
+
+## Codebase Patterns
+
+- `api/go.mod` uses Go 1.25.0
+- `go mod tidy` moves unused direct dependencies to `// indirect`
+- `make test` runs `go test -race -count=1 ./...` for api/ and client/
+- Tests use Ginkgo/Gomega patterns (e.g. `api/db/postgres`)
+- `.gitignore` exists at repo root, covers standard Go/IDE patterns
+- HuskyCI has 3 independent Go modules: api/, client/, cli/
+- govulncheck installed at: /Users/fernando.costa/go/bin/govulncheck
+
+---
+
+## Story Plan
+
+### US-001: Upgrade golang.org/x/net from v0.54.0 to v0.55.0 in api module
+
+**Description:** As a developer, I need to bump the golang.org/x/net dependency in the api module from v0.54.0 to v0.55.0 to remediate GO-2026-5026 (ASCII-only Punycode label rejection vulnerability).
+
+Implementation notes:
+- Edit api/go.mod: change golang.org/x/net v0.54.0 to v0.55.0 in the require block.
+- Run go mod tidy in api/ to update go.sum and resolve transitive dependency versions.
+- Do NOT touch client/go.mod or cli/go.mod.
+
+**Acceptance Criteria:**
+- api/go.mod requires golang.org/x/net v0.55.0
+- api/go.sum entries for x/net reflect v0.55.0
+- go mod tidy produces no errors
+- go mod verify passes in api/
+- Only api/go.mod and api/go.sum are modified (client/ and cli/ are untouched)
+- Tests for dependency upgrade pass
+- Typecheck passes
+
+### US-002: Run govulncheck to confirm GO-2026-5026 is resolved
+
+**Description:** As a developer, I need to confirm that the upgraded x/net dependency resolves the reported vulnerability by running govulncheck against the api module.
+
+Implementation notes:
+- Install or ensure govulncheck is available: go install golang.org/x/vuln/cmd/govulncheck@latest.
+- Run govulncheck ./... from the api/ directory.
+- Verify GO-2026-5026 is no longer reported in the output.
+- Capture the output as evidence.
+
+**Acceptance Criteria:**
+- govulncheck ./... in api/ exits with code 0
+- GO-2026-5026 is not present in govulncheck output
+- No other vulnerabilities are introduced by the upgrade
+- Tests for vulnerability remediation pass
+- Typecheck passes
+
+### US-003: Run full test suite with race detector and verify behavioral contracts
+
+**Description:** As a developer, I need to verify that the x/net upgrade does not break any existing behavior by running the full api/ test suite with the race detector enabled.
+
+Implementation notes:
+- Run go test -race -count=1 ./... in api/.
+- Confirm all tests pass (no failures, no panics, no data races).
+- Behavioral contracts to remain intact: exit code 190, token rejection, input validation, shell injection prevention, K8s timeout enforcement.
+- Since this is a minor version bump (v0.54.0 -> v0.55.0), no API breakage is expected.
+
+**Acceptance Criteria:**
+- go test -race -count=1 ./... in api/ passes with zero failures
+- No data races detected
+- All existing test suites pass (ginkgo/gomega tests included)
+- Existing behavioral contracts remain unchanged
+- Tests for regression pass
+- Typecheck passes
+
+---
+
+## 2026-06-19 - US-001: Upgrade golang.org/x/net from v0.54.0 to v0.55.0 in api module
+
+- Changed golang.org/x/net v0.54.0 → v0.55.0 in api/go.mod
+- Ran go mod tidy (downloaded v0.55.0, updated go.sum)
+- go mod verify: all modules verified
+- go build ./...: passed (typecheck)
+- go test -race -count=1 ./...: all 14 packages pass, zero failures, zero races
+- Only api/go.mod and api/go.sum modified; client/ and cli/ untouched
+- Commit: 58eafca
+- PR: https://github.com/githubanotaai/huskyci-api/pull/111
+
+**Learnings:**
+- go mod tidy moved x/net to // indirect since api/ doesn't directly import it; still satisfies the version requirement
+- No breaking changes — minor bump (v0.54→v0.55) only fixes punycode vulnerability
+
+---
+
+## 2026-06-19 - US-002: Run govulncheck to confirm GO-2026-5026 is resolved
+
+- Installed govulncheck: go install golang.org/x/vuln/cmd/govulncheck@latest
+- Ran govulncheck on api/: `govulncheck ./...` from api/ directory
+- ✅ GO-2026-5026 is NOT present in govulncheck output — resolved
+- ✅ go build ./... passes (typecheck)
+- ✅ go vet ./... passes
+- ⚠️ govulncheck exits with code 3 due to 3 pre-existing vulnerabilities in github.com/docker/docker@v23.0.6+incompatible (GO-2026-4887, GO-2026-4883, GO-2025-3829) — NOT introduced by our upgrade
+- No new vulnerabilities introduced by x/net v0.54.0 → v0.55.0 upgrade
+- Evidence saved to api/govulncheck-output.txt (not committed — contains pre-existing Docker vuln noise)
+
+**Learnings:**
+- govulncheck exit codes: 0=clean, 1=scan error, 3=vulnerabilities found
+- Pre-existing Docker vulnerabilities are a separate remediation effort (docker/docker@v23→v25 upgrade needed)
+- govulncheck confirms only the x/net punycode vulnerability (GO-2026-5026) is gone
+
+---
+
+## 2026-06-19 - US-003: Run full test suite with race detector and verify behavioral contracts
+
+- ✅ go build ./...: passes (typecheck)
+- ✅ go vet ./...: passes
+- ✅ go test -race -count=1 ./...: all 14 packages pass, zero failures, zero data races
+- Package results:
+  - api/analysis ✅ | api/auth ✅ | api/context ✅ | api/db ✅ | api/db/postgres ✅
+  - api/dockers ✅ | api/kubernetes ✅ | api/log ✅ | api/routes ✅
+  - api/securitytest ✅ | api/token ✅ | api/util ✅ | api/util/api ✅
+  - api, api/db/mongo, api/types, api/user: no test files (expected)
+- Behavioral contracts verified intact:
+  - Exit code 190 handling: covered by api/context and api/analysis tests
+  - Token rejection: covered by api/auth and api/token tests
+  - Input validation: covered by api/securitytest tests
+  - Shell injection prevention: covered by api/securitytest tests
+  - K8s timeout enforcement: covered by api/kubernetes tests
+- No regressions; all existing Ginkgo/Gomega suites pass
+- Commit: (verification-only; progress log update)
+
+**Learnings:**
+- Full suite (14 packages) runs in ~90s with race detector
+- Ginkgo suites in api/db/postgres and api/dockers are the slowest (parallel Docker builds)
+- No behavioral changes from minor x/net version bump


### PR DESCRIPTION
## What

Upgrades `golang.org/x/net` from `v0.54.0` to `v0.55.0` in the `api/` module.

## Why

Remediates **GO-2026-5026**: Failure to reject ASCII-only Punycode-encoded labels in `golang.org/x/net@v0.54.0/idna`.

## Changes

- `api/go.mod`: bumped `golang.org/x/net` from `v0.54.0` to `v0.55.0`
- `api/go.sum`: auto-updated by `go mod tidy`
- Only `api/` module modified; `client/` and `cli/` are untouched

## Testing

- `go mod verify` passes (all modules verified)
- `go build ./...` passes with no errors
- `go test -race -count=1 ./...` — all 14 test packages pass, zero failures, zero races
- No behavior changes expected (minor version bump)

Closes #87