### PR TITLE
fix: Upgrade github.com/ulikunitz/xz from v0.5.11 to v0.5.15 (GO-2025-3922)

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/src-d/go-oniguruma v1.1.0 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
 	github.com/toqueteos/trie v1.0.0 // indirect
-	github.com/ulikunitz/xz v0.5.11 // indirect
+	github.com/ulikunitz/xz v0.5.15 // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	golang.org/x/net v0.37.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -222,8 +222,8 @@ github.com/subosito/gotenv v1.4.2/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNG
 github.com/toqueteos/trie v1.0.0 h1:8i6pXxNUXNRAqP246iibb7w/pSFquNTQ+uNfriG7vlk=
 github.com/toqueteos/trie v1.0.0/go.mod h1:Ywk48QhEqhU1+DwhMkJ2x7eeGxDHiGkAdc9+0DYcbsM=
 github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
-github.com/ulikunitz/xz v0.5.11 h1:kpFauv27b6ynzBNT/Xy+1k+fK4WswhN/6PN5WhFAGw8=
-github.com/ulikunitz/xz v0.5.11/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
+github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
+github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
## Summary

Upgrade `github.com/ulikunitz/xz` from v0.5.11 to v0.5.15 in the `cli/` module to remediate **GO-2025-3922**: memory leaks when decoding corrupted LZMA archives.

## Changes

- `cli/go.mod`: Bumped `github.com/ulikunitz/xz` from v0.5.11 → v0.5.15
- `cli/go.sum`: Auto-updated checksums

This is an indirect dependency pulled by `mholt/archiver`. The upgrade is a patch-level bump within the same minor version range.

## Verification

- ✅ `go mod tidy` in `cli/` completes without error
- ✅ `go build ./cli` compiles successfully
- ✅ `go test -race -count=1 ./cli/...` — all existing tests pass
- ✅ `govulncheck ./cli/...` — GO-2025-3922 no longer reported
- ✅ `cli/go.sum` contains v0.5.15 hash, no v0.5.11 entry

Closes #92