### PR TITLE
fix: G115 integer overflow — validate poolLimit before uint64 conversion

### DIFF
--- a/api/db/mongo/mongo.go
+++ b/api/db/mongo/mongo.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -48,6 +49,9 @@ type Database interface {
 
 // Connect connects to mongo and returns the session.
 func Connect(address, dbName, username, password string, poolLimit, port int, timeout time.Duration) error {
+	if poolLimit < 0 {
+		return errors.New("pool limit cannot be negative")
+	}
 
 	log.Info(logActionConnect, logInfoMongo, 21)
 	dbAddress := fmt.Sprintf("%s:%d", address, port)

--- a/api/db/mongo/mongo_test.go
+++ b/api/db/mongo/mongo_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Globo.com authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package db
+
+import (
+	"testing"
+	"time"
+
+	"github.com/githubanotaai/huskyci-api/api/log"
+)
+
+// stubLogger is a no-op logger that satisfies the log.logger interface.
+type stubLogger struct{}
+
+func (s *stubLogger) SendLog(extra map[string]interface{}, loglevel string, messages ...interface{}) error {
+	return nil
+}
+
+func init() {
+	// Install a stub logger so that Connect's log calls don't panic on nil Logger.
+	log.Logger = &stubLogger{}
+}
+
+// TestConnectNegativePoolLimit verifies that Connect returns an error
+// immediately when poolLimit < 0, without attempting any MongoDB operations.
+func TestConnectNegativePoolLimit(t *testing.T) {
+	t.Parallel()
+
+	err := Connect("localhost", "testdb", "user", "pass", -1, 27017, 10*time.Second)
+	if err == nil {
+		t.Fatal("expected error for negative poolLimit, got nil")
+	}
+	if err.Error() != "pool limit cannot be negative" {
+		t.Fatalf("unexpected error message: %q", err.Error())
+	}
+}
+
+// TestConnectZeroPoolLimit verifies that Connect does NOT return a validation
+// error when poolLimit is zero (the validation guard only rejects negative values).
+func TestConnectZeroPoolLimit(t *testing.T) {
+	t.Parallel()
+
+	err := Connect("localhost", "testdb", "user", "pass", 0, 27017, 10*time.Second)
+	if err != nil && err.Error() == "pool limit cannot be negative" {
+		t.Fatalf("unexpected validation error for zero poolLimit: %v", err)
+	}
+	// Connection failure (e.g., no MongoDB running) is expected and irrelevant
+	// to the validation behavior under test.
+}
+
+// TestConnectPositivePoolLimit verifies that Connect does NOT return a validation
+// error when poolLimit is positive.
+func TestConnectPositivePoolLimit(t *testing.T) {
+	t.Parallel()
+
+	err := Connect("localhost", "testdb", "user", "pass", 100, 27017, 10*time.Second)
+	if err != nil && err.Error() == "pool limit cannot be negative" {
+		t.Fatalf("unexpected validation error for positive poolLimit: %v", err)
+	}
+	// Connection failure (e.g., no MongoDB running) is expected and irrelevant
+	// to the validation behavior under test.
+}


### PR DESCRIPTION
## Summary

Fixes integer overflow vulnerability (G115) in `api/db/mongo/mongo.go:57` where an unsafe `int → uint64` conversion could wrap negative values to huge positive uint64 values.

## Changes

- **api/db/mongo/mongo.go**: Added a validation guard at the top of `Connect()` that returns an error immediately when `poolLimit < 0`, preventing the unsafe conversion entirely.
- **api/db/mongo/mongo_test.go**: Added comprehensive unit tests for negative, zero, and positive poolLimit values. All tests use `t.Parallel()`.

## Testing

- `go test -race -count=1 ./db/mongo/` — all tests pass
- G115 high-severity finding for `api/db/mongo/mongo.go` is resolved
- Behavioral contracts are intact (no other files modified):
  - client/ exit code 190: unchanged
  - api/token/token.go:120 cross-repo token rejection: unchanged
  - api/util/util.go:169-219 input validators: unchanged
  - api/config.yaml shell injection prevention: unchanged
- Confirmed bug locations untouched

## Related

Closes #95