### PR TITLE
docs: reassess GO-2026-4883 docker/docker plugin advisory at v25.0.13 — confirmed false positive

### DIFF
--- a/docs/assessments/go-2026-4883-docker-plugin.md
+++ b/docs/assessments/go-2026-4883-docker-plugin.md
@@ -1,6 +1,6 @@
 # GO-2026-4883 Vulnerability Assessment
 
-**Date:** 2026-06-19
+**Date:** 2026-06-21
 **Assessor:** Tamandua Developer Agent (feature-dev-github-pr workflow)
 **Status:** Accepted Exception (False Positive for huskyci-api)
 
@@ -12,7 +12,7 @@
 |-------|--------|
 | **CVE/Advisory** | GO-2026-4883 |
 | **Description** | Off-by-one error in Moby plugin privilege validation |
-| **Affected Package** | `github.com/docker/docker` v23.0.6+incompatible |
+| **Affected Package** | `github.com/docker/docker` v25.0.13+incompatible |
 | **Vulnerable Component** | Docker plugin system privilege validation |
 | **Fixed Version** | None available upstream |
 | **Severity** | Medium |
@@ -27,7 +27,7 @@ The vulnerability exists in Moby's (Docker Engine) plugin privilege validation l
 | Field | Detail |
 |-------|--------|
 | **Module** | `github.com/docker/docker` |
-| **Version** | `v23.0.6+incompatible` |
+| **Version** | `v25.0.13+incompatible` |
 | **Dependency Type** | Direct (declared in `api/go.mod`) |
 | **Import Path** | `github.com/docker/docker/client` (and types packages) |
 | **Used In** | `api/dockers/api.go`, `api/dockers/huskydocker.go` |
@@ -209,6 +209,43 @@ The finding is a false positive for huskyci-api because:
 - The vulnerable code path is unreachable by construction
 
 This assessment is recorded as the official exception for GO-2026-4883 in the huskyci-api project.
+
+---
+
+## Re-assessment (v25.0.13)
+
+**Date:** 2026-06-21
+**Context:** Dependency upgrade from v23.0.6 to v25.0.13 (via PR #118)
+
+### Version Upgrade
+
+The `github.com/docker/docker` dependency in `api/go.mod` was upgraded from `v23.0.6+incompatible` to `v25.0.13+incompatible` as part of PR #118. This upgrade bumps the Moby (Docker Engine) version by two major releases but does **not** include a fix for GO-2026-4883 — the vulnerability remains unresolved upstream.
+
+### Re-audit at v25.0.13
+
+A full re-audit of the `api/` module was conducted at version v25.0.13:
+
+- **`rg 'Plugin' api/ --type go`**: Returns exactly 2 non-overlapping match groups:
+  1. The existing comment block in `api/dockers/api.go` (lines 48-50) documenting that no Plugin* calls exist
+  2. `api/securitytest/spotbugs.go:37` — `Plugin string \`xml:"Plugin"\`` field in the SpotBugs XML Project struct (domain-level XML parsing, unrelated to Docker plugin subsystem)
+- **Zero Plugin* method calls or type imports** exist in the entire `api/` module
+- All Docker client calls remain container/image lifecycle operations only (ContainerCreate, ContainerStart, ContainerLogs, ImagePull, ImageRemove, etc.)
+- `api/dockers/huskydocker.go` contains no plugin-related code
+
+### Confirmations
+
+| Check | Result |
+|-------|--------|
+| Plugin API calls in api/ | **0** |
+| Plugin type imports in api/ | **0** |
+| Plugin code path reachable | **No** |
+| Full test suite (15 packages, `-race`) | **Pass** |
+| `go vet ./...` | **Clean** |
+| `go build ./...` | **Clean** |
+
+### Conclusion
+
+The plugin privilege validation code path remains **completely unreachable** from huskyci-api at docker/docker v25.0.13+incompatible. The GO-2026-4883 finding continues to be a **false positive — accepted exception**. No code changes are required or planned.
 
 ---
 

--- a/progress-b95ad3ae-52f9-42a3-bf73-a916cba0ca25.txt
+++ b/progress-b95ad3ae-52f9-42a3-bf73-a916cba0ca25.txt
@@ -9,6 +9,7 @@ Started: 2026-06-21
 - **Test command:** `cd api && go test -race -count=1 ./...` — 15 packages, dockers tests take ~33s
 - **Lint/build:** `cd api && go vet ./... && go build ./...`
 - **Go module layout:** Three independent modules — `api/`, `client/`, `cli/` — each with own go.mod
+- **Vulnerability assessment docs:** Located in `docs/assessments/` with naming convention `go-XXXX-XXXX-<component>.md`
 
 ## Story Plan
 
@@ -68,6 +69,7 @@ Implementation notes:
 - All test packages pass identically to baseline
 - Typecheck passes
 
+
 ---
 ## 2026-06-21T00:00:00Z - US-001: Re-audit api/ module for Plugin* calls and confirm continued non-exploitability at docker/docker v25.0.13
 - **Implemented:** Full re-audit of api/ module for Plugin* symbols
@@ -82,4 +84,32 @@ Implementation notes:
   - Full test suite passes: 15 packages ok, dockers package at 32.9s
   - `go vet` and `go build` clean
   - **Conclusion:** Plugin code path remains completely unreachable. GO-2026-4883 is still a false positive.
+---
+## 2026-06-21T00:00:00Z - US-002: Update GO-2026-4883 vulnerability assessment document with current version re-assessment
+- **Implemented:** Updated docs/assessments/go-2026-4883-docker-plugin.md with current version re-assessment
+- **Files changed:** docs/assessments/go-2026-4883-docker-plugin.md (+40, -3)
+- **Changes:**
+  - Date updated from 2026-06-19 to 2026-06-21
+  - Affected Package version updated from v23.0.6+incompatible to v25.0.13+incompatible
+  - Added "Re-assessment (v25.0.13)" section with version upgrade context, re-audit findings, confirmation table, and conclusion
+  - Govulncheck section preserved as historical (original scan at v23.0.6)
+- **No .go files modified** (documentation only)
+- **Tests:** Full suite passes — 15 packages ok, dockers at 33.9s; go vet clean; go build clean
+- **Learnings:**
+  - The assessment doc uses the govulncheck section as a historical record of the original scan; version references there should NOT be updated
+  - Re-assessment section lives between Conclusion and References
+---
+## 2026-06-21 - US-003: Run full test suite and vet to validate no regressions from documentation changes
+- **Implemented:** Full validation suite — no code changes, verification only
+- **Files changed:** progress-b95ad3ae-52f9-42a3-bf73-a916cba0ca25.txt (this file, progress update only)
+- **Results:**
+  - `go vet ./...`: clean, zero warnings
+  - `go build ./...`: clean, all packages compile
+  - `go test -race -count=1 ./...`: 17 packages total, 12 with tests (all ok), 3 without test files
+    - dockers: 32.8s (consistent with baseline of 32.9s and 33.9s from prior runs)
+    - All other packages pass identically to US-001 and US-002 baselines
+  - Zero regressions from documentation-only changes
+- **Learnings:**
+  - dockers package test timing is stable at ~33s across all three runs, confirming no hidden overhead introduced
+  - Documentation-only changes have zero impact on build or test results
 ---

--- a/progress-b95ad3ae-52f9-42a3-bf73-a916cba0ca25.txt
+++ b/progress-b95ad3ae-52f9-42a3-bf73-a916cba0ca25.txt
@@ -1,0 +1,85 @@
+# Progress Log
+Run: b95ad3ae-52f9-42a3-bf73-a916cba0ca25
+Task: Implement issue #89: GO-2026-4883 govulncheck advisory on github.com/docker/docker
+Started: 2026-06-21
+
+## Codebase Patterns
+
+- **Docker client usage:** All Docker operations go through `api/dockers/api.go` (Docker struct) and `api/dockers/huskydocker.go` (orchestration wrapper). Only container/image lifecycle methods are used; no plugin subsystem.
+- **Test command:** `cd api && go test -race -count=1 ./...` — 15 packages, dockers tests take ~33s
+- **Lint/build:** `cd api && go vet ./... && go build ./...`
+- **Go module layout:** Three independent modules — `api/`, `client/`, `cli/` — each with own go.mod
+
+## Story Plan
+
+### US-001: Re-audit api/ module for Plugin* calls and confirm continued non-exploitability at docker/docker v25.0.13
+
+**Description:** As a developer, I need to verify that zero Plugin* method calls or type imports exist in the api/ module at the current docker/docker v25.0.13+incompatible, confirming the vulnerability remains unreachable.
+
+Implementation notes:
+- Run `rg -rn 'Plugin' api/ --include='*.go'` to search for Plugin* symbols
+- Confirm the only matches are the existing comment block in api/dockers/api.go (which documents the absence) and the unrelated spotbugs XML field
+- Verify go.mod shows github.com/docker/docker v25.0.13+incompatible
+- Record findings in a brief audit note to be used by US-002
+
+**Acceptance Criteria:**
+- rg/grep for Plugin* in api/*.go returns zero new code-level matches beyond existing comment and spotbugs
+- go.mod confirms docker/docker at v25.0.13+incompatible
+- All Docker API client calls are container/image operations only (no plugin subsystem calls)
+- Tests for docker package pass
+- Typecheck passes
+
+### US-002: Update GO-2026-4883 vulnerability assessment document with current version re-assessment
+
+**Description:** As a developer, I need to update docs/assessments/go-2026-4883-docker-plugin.md to reflect the current docker/docker v25.0.13+incompatible, add a re-assessment section confirming continued non-exploitability, update the date, and reference the current Moby version.
+
+Implementation notes:
+- Update Date field to current date (2026-06-21)
+- Update Affected Package version from v23.0.6+incompatible to v25.0.13+incompatible
+- Add a 'Re-assessment (v25.0.13)' section documenting:
+  - Version upgrade from v23.0.6 to v25.0.13 (via PR #118)
+  - Re-audit confirms zero Plugin* calls at current version
+  - Plugin code path remains completely unreachable
+  - Finding is still a false positive — accepted exception
+- Reference current Moby version (v25.0.13)
+- Do NOT modify any .go files (documentation only)
+- Do NOT auto-merge — this will go to PR for human review
+
+**Acceptance Criteria:**
+- Assessment doc Date is updated to current date
+- Affected Package shows v25.0.13+incompatible
+- Re-assessment section confirms continued false positive at v25.0.13
+- Current Moby version referenced
+- No .go files modified outside existing assessment comment in api/dockers/api.go
+- Typecheck passes
+
+### US-003: Run full test suite and vet to validate no regressions from documentation changes
+
+**Description:** As a developer, I need to run the full test suite with race detection and go vet to confirm no regressions exist after the documentation-only changes.
+
+Implementation notes:
+- Run `cd api && go test -race -count=1 ./...` — all packages must pass
+- Run `cd api && go vet ./...` — must produce no warnings
+- No code changes expected — tests should pass identically to pre-change state
+
+**Acceptance Criteria:**
+- cd api && go test -race -count=1 ./... passes all packages
+- cd api && go vet ./... produces zero warnings
+- All test packages pass identically to baseline
+- Typecheck passes
+
+---
+## 2026-06-21T00:00:00Z - US-001: Re-audit api/ module for Plugin* calls and confirm continued non-exploitability at docker/docker v25.0.13
+- **Implemented:** Full re-audit of api/ module for Plugin* symbols
+- **Files checked:** api/dockers/api.go, api/dockers/huskydocker.go, api/securitytest/spotbugs.go, api/go.mod
+- **Learnings:**
+  - `rg 'Plugin' api/ --type go` returns exactly 2 non-overlapping match groups:
+    1. Comment block in `api/dockers/api.go:48-50` documenting Plugin* absence
+    2. `api/securitytest/spotbugs.go:37` — `Plugin string \`xml:"Plugin"\`` field in SpotBugs XML Project struct (domain-level, NOT Docker plugin)
+  - `api/go.mod` confirms `github.com/docker/docker v25.0.13+incompatible` (upgraded from v23.0.6 via PR #118)
+  - All 17 Docker client method calls in `api/dockers/api.go` are container/image operations only
+  - `api/dockers/huskydocker.go` has zero Plugin references
+  - Full test suite passes: 15 packages ok, dockers package at 32.9s
+  - `go vet` and `go build` clean
+  - **Conclusion:** Plugin code path remains completely unreachable. GO-2026-4883 is still a false positive.
+---


### PR DESCRIPTION
## Summary

Updates `docs/assessments/go-2026-4883-docker-plugin.md` to reassess exploitability of the GO-2026-4883 advisory against the current docker/docker v25.0.13+incompatible.

## What Changed

- Updated Date to 2026-06-21
- Updated Affected Package version from v23.0.6+incompatible to v25.0.13+incompatible
- Added Re-assessment (v25.0.13) section documenting:
  - Version upgrade from v23.0.6 to v25.0.13 (via PR #118)
  - Re-audit confirms zero Plugin* method calls at current version
  - Plugin code path remains completely unreachable
  - Finding remains a false positive → accepted exception
- Referenced current Moby version (v25.0.13)
- Only documentation changes; no `.go` files modified

## Validation

- `cd api && go test -race -count=1 ./...` — all packages pass
- `cd api && go vet ./...` — zero warnings
- Re-audit confirmed zero Plugin* calls in api/ module

## Related

- Issue #89
- Prior PR #117 (initial assessment)
- Prior PR #118 (docker version bump)