### PR TITLE
fix: bump go.mongodb.org/mongo-driver in cli/ to v1.17.7 (resolve alert #65)

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/viper v1.15.0
 	github.com/src-d/enry/v2 v2.1.0
-	go.mongodb.org/mongo-driver v1.17.3
+	go.mongodb.org/mongo-driver v1.17.7
 )
 
 require (

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -212,8 +212,8 @@ github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-go.mongodb.org/mongo-driver v1.17.3 h1:TQyXhnsWfWtgAhMtOgtYHMTkZIfBTpMTsMnd9ZBeHxQ=
-go.mongodb.org/mongo-driver v1.17.3/go.mod h1:Hy04i7O2kC4RS06ZrhPRqj/u4DTYkFDAAccj+rVKqgQ=
+go.mongodb.org/mongo-driver v1.17.7 h1:a9w+U3Vt67eYzcfq3k/OAv284/uUUkL0uP75VE5rCOU=
+go.mongodb.org/mongo-driver v1.17.7/go.mod h1:Hy04i7O2kC4RS06ZrhPRqj/u4DTYkFDAAccj+rVKqgQ=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=


### PR DESCRIPTION
Fixes Dependabot alert #65 — Heap Out-Of-Bounds Read in GSSAPI Error Handling.

Bumps go.mongodb.org/mongo-driver from v1.17.3 to v1.17.7.

## Changes
- `cli/go.mod`: bumped go.mongodb.org/mongo-driver from v1.17.3 → v1.17.7
- `cli/go.sum`: updated checksums for new dependency version

No .go source files were modified.

## Testing
- `cd cli && go build ./...` ✅
- `cd cli && go vet ./...` ✅
- `cd cli && go test -race -count=1 ./...` ✅

Co-Authored-By: Tamandua <tamandua@tetradactyla.org>