### PR TITLE
feat: US-001, US-002, US-003 - Verify GO-2026-4883 false positive assessment (Issue #89)

### DIFF
--- a/docs/assessments/go-2026-4883-docker-plugin.md
+++ b/docs/assessments/go-2026-4883-docker-plugin.md
@@ -259,5 +259,38 @@ The plugin privilege validation code path remains **completely unreachable** fro
 
 ---
 
+---
+
+## Formal Verification (2026-06-21)
+
+A full integration/E2E verification was performed against commit `da3decc` on branch `feature/issue-89-go-2026-4883-verify` to confirm the assessment conclusions.
+
+### Verification Results
+
+| Check | Result |
+|-------|--------|
+| `go test -race -count=1 ./...` (api/) | **PASS** — 15/15 packages, race detector clean |
+| `go vet ./...` (api/) | **CLEAN** — zero warnings |
+| `go build ./...` (api/) | **CLEAN** — compiles without error |
+| `gofmt -l .` (api/) | **CLEAN** — all files properly formatted |
+| `grep -rn Plug api/dockers/` | **CLEAN** — only assessment comment references |
+| `grep -rn Plug api/ --include='*.go'` | **CLEAN** — only comment + unrelated `spotbugs.go` XML field |
+| Assessment doc present | **YES** — `docs/assessments/go-2026-4883-docker-plugin.md` |
+| v25.0.13 re-assessment section | **YES** — present and complete |
+| Code comment in `api/dockers/api.go` | **YES** — GO-2026-4883 VULNERABILITY ASSESSMENT block |
+| Regressions | **NONE** — zero test failures, zero vet/build issues |
+
+### Cross-Story Validation Summary
+
+- **US-001 (Assessment Document):** Complete — v25.0.13 re-assessment, Accepted Exception (False Positive) status, all required sections present
+- **US-002 (Code Comment):** Complete — `api/dockers/api.go` contains the GO-2026-4883 vulnerability assessment comment listing actual operations and confirming Plugin* methods are never called
+- **US-003 (Validation Suite):** Complete — full test suite passes with race detector, vet and build clean, zero regressions
+
+### Verification Conclusion
+
+All acceptance criteria for Issue #89 are satisfied. The GO-2026-4883 finding is confirmed as a **false positive — accepted exception** for huskyci-api. No remediation action is required. The assessment documentation and code comments accurately capture the unreachability of the vulnerable code path.
+
+---
+
 *This assessment was produced by the Tamandua feature-dev-github-pr workflow as part of huskyci-api issue #89 remediation.*
 *No .go files outside this document were modified.*


### PR DESCRIPTION
## Description

Formal verification of the GO-2026-4883 false positive assessment for the HuskyCI API repository (Issue #89).

## What Was Verified

### US-001: Assessment Document
- `docs/assessments/go-2026-4883-docker-plugin.md` exists and is complete
- Contains v25.0.13 re-assessment section
- Status: Accepted Exception (False Positive) — vulnerability is unreachable

### US-002: Code Comment
- `GO-2026-4883 VULNERABILITY ASSESSMENT` comment exists in `api/dockers/api.go`
- Documents that zero Plugin* methods are called
- Lists actual container/image operations used

### US-003: Validation Suite
| Check | Result |
|-------|--------|
| `go test -race -count=1 ./...` (api/) | **PASS** — 15/15 packages |
| `go vet ./...` (api/) | **CLEAN** |
| `go build ./...` (api/) | **CLEAN** |
| `gofmt -l .` (api/) | **CLEAN** |
| Plugin* calls (api/dockers/) | **CLEAN** — only comment refs |
| Plugin* calls (api/\*.go) | **CLEAN** — only comment + spotbugs XML field |
| Regressions | **NONE** |

## Changes
- Added formal verification results section to `docs/assessments/go-2026-4883-docker-plugin.md`

## Linked Issue
Closes #89

## Testing
Full test suite runs clean with race detector. No new test files required (documentation-only changes).

Co-Authored-By: Tamandua <tamandua@tetradactyla.org>