### PR TITLE
feat: Document GO-2026-4887 as false positive (Moby AuthZ plugin bypass)

### DIFF
--- a/api/dockers/api.go
+++ b/api/dockers/api.go
@@ -122,6 +122,46 @@ package dockers
 // Status: Risk Accepted — not exploitable in huskyci-api deployment.
 // Will reassess when upstream Moby releases a fix.
 
+// GO-2026-4887 VULNERABILITY ASSESSMENT
+//
+// The vulnerability GO-2026-4887 is a Moby AuthZ plugin bypass in
+// github.com/docker/docker. No fixed version is available upstream.
+//
+// HuskyCI uses the Docker client SDK strictly for scanner container management.
+// A full audit of every d.client method call confirms the following operations
+// are used:
+//
+//   CONTAINER OPERATIONS:
+//     - ContainerCreate
+//     - ContainerStart
+//     - ContainerWait
+//     - ContainerStop
+//     - ContainerRemove
+//     - ContainerList
+//     - ContainerLogs
+//
+//   IMAGE OPERATIONS:
+//     - ImagePull
+//     - ImageList
+//     - ImageRemove
+//
+//   MISC:
+//     - Ping
+//
+//   IMPORTS (api/dockers/api.go):
+//     - github.com/docker/docker/api/types/container
+//     - github.com/docker/docker/api/types/filters
+//     - github.com/docker/docker/api/types/image (dockerImage)
+//     - github.com/docker/docker/client
+//
+// Zero AuthZ plugin-related method calls (PluginList, PluginInstall, PluginInspect,
+// PluginRemove, PluginSet, PluginEnable, PluginDisable, PluginUpgrade, etc.)
+// or Plugin* types exist anywhere in the api/ module. The AuthZ plugin code path
+// is completely unreachable from the Docker client SDK operations used by huskyci-api.
+//
+// Status: Risk Accepted — false positive in huskyci-api deployment.
+// Will reassess when upstream Moby releases a fix.
+
 import (
 	"fmt"
 	"os"

--- a/docs/advisories/GO-2026-4887.md
+++ b/docs/advisories/GO-2026-4887.md
@@ -32,7 +32,7 @@ gaining unauthorized access to Docker daemon operations.
 | **Affected Version** | `v25.0.13+incompatible` |
 | **Fixed Version** | N/A (no fix published upstream) |
 | **Dependency Type** | Direct dependency in `api/go.mod` |
-| **Imported Packages** | `api/types`, `api/types/container`, `api/types/filters`, `api/types/image`, `client` |
+| **Imported Packages** | `api/types/container`, `api/types/filters`, `api/types/image`, `client` |
 
 The module is imported by `api/dockers/api.go` for standard Docker container
 lifecycle operations. Traces also appear through `api/kubernetes/api.go` via
@@ -41,6 +41,15 @@ transitive dependencies.
 ---
 
 ## 3. HuskyCI Usage Analysis
+
+### Code-Level Assessment
+
+A full vulnerability assessment for GO-2026-4887 has been added as a comment
+block in `api/dockers/api.go` (see the `// GO-2026-4887 VULNERABILITY ASSESSMENT`
+section near the top of the file, before the `import` block). This comment
+documents the complete method call audit, import listing, reachability analysis,
+and Risk Accepted status in the code itself alongside the other CVE assessments
+(GO-2026-4883, CVE-2026-41567, CVE-2026-42306).
 
 ### Docker Client Operations
 
@@ -76,7 +85,6 @@ Docker AuthZ plugins in any way.
 **No** authorization-related packages from `github.com/docker/docker` are
 imported anywhere in the `api/` module. The only Docker imports are:
 
-- `github.com/docker/docker/api/types`
 - `github.com/docker/docker/api/types/container`
 - `github.com/docker/docker/api/types/filters`
 - `github.com/docker/docker/api/types/image`


### PR DESCRIPTION
## Summary

Documents GO-2026-4887 (Moby AuthZ plugin bypass in `github.com/docker/docker`) as a **false positive** in huskyci-api.

## Changes

### US-001: Add vulnerability assessment comment in `api/dockers/api.go`
- Added a GO-2026-4887 VULNERABILITY ASSESSMENT comment block following the exact same format as existing CVE assessments (GO-2026-4883, CVE-2026-41567, CVE-2026-42306)
- Confirms zero AuthZ plugin-related method calls or Plugin* types in the api/ module
- HuskyCI only uses the Docker client SDK for scanner container lifecycle management (ContainerCreate, ContainerStart, ContainerWait, ContainerStop, etc.)

### US-002: Update `docs/advisories/GO-2026-4887.md`
- Added code-level assessment reference to the new comment block in api/dockers/api.go
- Corrected import listings to match current codebase state (v25.0.13)

## Testing

```
cd api && go test -race -count=1 ./...  # all 16 packages pass
cd api && go vet ./...                  # clean
cd api && gofmt -l .                    # clean (no output)
cd api && go build ./...                # passes
```

## Files Changed

- `api/dockers/api.go`: +40 lines (comment-only, no behavioral changes)
- `docs/advisories/GO-2026-4887.md`: +12/-2 lines

Closes #88