### PR TITLE
chore: add setup-qemu and build-amd64 Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,3 +178,25 @@ test:
 
 ## Builds and push securityTest containers with the latest tags
 update-containers: build-containers push-containers
+
+## Installs QEMU binfmt for cross-platform Docker builds (needed on ARM Macs)
+setup-qemu:
+	@echo "Installing QEMU binfmt for cross-platform Docker builds..."
+	docker run --privileged --rm tonistiigi/binfmt --install all
+	@echo "Done. Supported platforms:"
+	@docker buildx inspect default 2>/dev/null | grep -m1 Platforms || true
+
+## Builds and pushes huskyci-client Docker image for linux/amd64
+build-amd64:
+	@[ -n "$$ECR_REGISTRY" ] || ( \
+		echo "ERROR: ECR_REGISTRY is not set." >&2; \
+		echo "  export ECR_REGISTRY=<account_id>.dkr.ecr.<region>.amazonaws.com" >&2; \
+		exit 1 \
+	)
+	@echo "Building huskyci-client for linux/amd64..."
+	chmod +x deployments/scripts/push-huskyci-client-ecr.sh
+	IMAGE_TAG=$${IMAGE_TAG:-$(shell git rev-parse --short HEAD)-amd64} \
+		./deployments/scripts/push-huskyci-client-ecr.sh $${IMAGE_TAG}
+
+## Builds and pushes huskyci-client Docker image for linux/amd64 (alias: require QEMU first)
+amd64: setup-qemu build-amd64


### PR DESCRIPTION
## What

Adds two Makefile targets for building `huskyci-client` on Apple Silicon Macs:

- `make setup-qemu` — installs QEMU/binfmt for cross-platform Docker builds
- `make build-amd64` — builds and pushes the image for linux/amd64 using the existing push script
- `make amd64` — alias that runs both in sequence

## Why

Building Docker images with `--platform linux/amd64` on ARM Macs requires QEMU emulation for any `RUN` steps in the Dockerfile. Without it, the resulting image is silently built for the host architecture (arm64), causing `ImagePullBackOff` on amd64 runner nodes.

The push script already has `--platform linux/amd64` but provides no guidance on the prerequisite QEMU setup. These Makefile targets make the workflow explicit.

## Usage

```bash
# One-time setup (ARM Mac only)
make setup-qemu

# Build and push
export ECR_REGISTRY=<account_id>.dkr.ecr.<region>.amazonaws.com
make build-amd64

# Or all at once
export ECR_REGISTRY=<account_id>.dkr.ecr.<region>.amazonaws.com
make amd64
```

The `make build-amd64` target calls the existing `deployments/scripts/push-huskyci-client-ecr.sh` script. The Makefile itself contains no company-specific information — all configuration comes from env vars.